### PR TITLE
feat: add Stealth Mode and Chain Mode (P1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ dist-ssr
 *.sw?
 
 console.txt
-har.txt
+har.txt.worktrees

--- a/src/__tests__/chain-mode.test.ts
+++ b/src/__tests__/chain-mode.test.ts
@@ -1,8 +1,50 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '../__tests__/chrome-mock';
 import { DEFAULT_SETTINGS } from '../shared/types';
+
+// Reset queue-engine module state between tests
+let QueueEngine: typeof import('../background/queue-engine');
 
 describe('chain mode types', () => {
   it('should default chainMode to false', () => {
     expect(DEFAULT_SETTINGS.chainMode).toBe(false);
+  });
+});
+
+describe('chain propagation in queue', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    QueueEngine = await import('../background/queue-engine');
+    await QueueEngine.clearQueue();
+  });
+
+  it('should set chainPreviousRefId on specified task', async () => {
+    await QueueEngine.addPrompts([
+      { prompt: 'task1' },
+      { prompt: 'task2' },
+    ]);
+    const { queue } = await QueueEngine.getAppState();
+    const task2 = queue.tasks[1];
+
+    await QueueEngine.setChainRef(task2.id, 'chain-ref-123');
+
+    const { queue: updated } = await QueueEngine.getAppState();
+    expect(updated.tasks[1].chainPreviousRefId).toBe('chain-ref-123');
+    expect(updated.tasks[0].chainPreviousRefId).toBeUndefined();
+  });
+
+  it('should not crash when setting chain ref on non-existent task', async () => {
+    await QueueEngine.setChainRef('nonexistent', 'ref-abc');
+    const { queue } = await QueueEngine.getAppState();
+    expect(queue.tasks).toHaveLength(0);
+  });
+
+  it('should preserve chainPreviousRefId through getNextWaitingTask', async () => {
+    await QueueEngine.addPrompts([{ prompt: 'task1' }]);
+    const { queue } = await QueueEngine.getAppState();
+    await QueueEngine.setChainRef(queue.tasks[0].id, 'chain-xyz');
+
+    const next = await QueueEngine.getNextWaitingTask();
+    expect(next?.chainPreviousRefId).toBe('chain-xyz');
   });
 });

--- a/src/__tests__/chain-mode.test.ts
+++ b/src/__tests__/chain-mode.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_SETTINGS } from '../shared/types';
+
+describe('chain mode types', () => {
+  it('should default chainMode to false', () => {
+    expect(DEFAULT_SETTINGS.chainMode).toBe(false);
+  });
+});

--- a/src/__tests__/stealth-mode.test.ts
+++ b/src/__tests__/stealth-mode.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { STEALTH } from '../shared/config';
+import { calcStealthDelay } from '../content/utils/dom';
+
+describe('stealth mode constants', () => {
+  it('should define valid multiplier range', () => {
+    expect(STEALTH.MULTIPLIER_MIN).toBeGreaterThanOrEqual(1.5);
+    expect(STEALTH.MULTIPLIER_MAX).toBeLessThanOrEqual(3.0);
+    expect(STEALTH.MULTIPLIER_MIN).toBeLessThan(STEALTH.MULTIPLIER_MAX);
+  });
+
+  it('should define valid pause range', () => {
+    expect(STEALTH.PAUSE_MIN_MS).toBeGreaterThanOrEqual(500);
+    expect(STEALTH.PAUSE_MAX_MS).toBeLessThanOrEqual(2000);
+    expect(STEALTH.PAUSE_MIN_MS).toBeLessThan(STEALTH.PAUSE_MAX_MS);
+  });
+
+  it('should cap total slowdown at 4x', () => {
+    expect(STEALTH.MAX_SLOWDOWN_FACTOR).toBe(4);
+  });
+});
+
+describe('stealth delay calculation', () => {
+  it('should produce delay within multiplier range', () => {
+    const baseDelay = 1000;
+    for (let i = 0; i < 100; i++) {
+      const factor = STEALTH.MULTIPLIER_MIN + Math.random() * (STEALTH.MULTIPLIER_MAX - STEALTH.MULTIPLIER_MIN);
+      const result = baseDelay * factor;
+      expect(result).toBeGreaterThanOrEqual(baseDelay * STEALTH.MULTIPLIER_MIN);
+      expect(result).toBeLessThanOrEqual(baseDelay * STEALTH.MULTIPLIER_MAX);
+    }
+  });
+});
+
+describe('calcStealthDelay', () => {
+  it('should return original range when stealth disabled', () => {
+    const [min, max] = calcStealthDelay(300, 600, false);
+    expect(min).toBe(300);
+    expect(max).toBe(600);
+  });
+
+  it('should multiply range when stealth enabled', () => {
+    const [min, max] = calcStealthDelay(300, 600, true);
+    expect(min).toBe(300 * STEALTH.MULTIPLIER_MIN);
+    expect(max).toBe(600 * STEALTH.MULTIPLIER_MAX);
+  });
+
+  it('should not exceed MAX_SLOWDOWN_FACTOR relative to original max', () => {
+    const [min, max] = calcStealthDelay(100, 200, true);
+    expect(max).toBeLessThanOrEqual(200 * STEALTH.MAX_SLOWDOWN_FACTOR);
+  });
+});

--- a/src/background/queue-engine.ts
+++ b/src/background/queue-engine.ts
@@ -320,3 +320,15 @@ export async function appendTaskLog(
   };
   await persist();
 }
+
+export async function setChainRef(taskId: string, refId: string): Promise<void> {
+  await ensureInitialized();
+  queue = {
+    ...queue,
+    tasks: queue.tasks.map((t) => {
+      if (t.id !== taskId) return t;
+      return { ...t, chainPreviousRefId: refId };
+    }),
+  };
+  await persist();
+}

--- a/src/background/queue-engine.ts
+++ b/src/background/queue-engine.ts
@@ -167,6 +167,10 @@ export async function removeTask(
   const removed = queue.tasks.find((t) => t.id === taskId);
   if (removed) {
     const refIds = collectAssetRefIds([removed]);
+    // Also clean up chain blob if present.
+    if (removed.chainPreviousRefId?.startsWith("chain-")) {
+      refIds.push(removed.chainPreviousRefId);
+    }
     if (refIds.length)
       void deleteImageBlobs(refIds).catch((e) =>
         logger.warn("deleteImageBlobs failed", e),
@@ -179,6 +183,15 @@ export async function removeTask(
   if (queue.currentTaskId === taskId) {
     queue.currentTaskId = undefined;
     queue.isRunning = false;
+  }
+  // Clear stale chain refs on remaining tasks when a task is removed.
+  if (settings.chainMode) {
+    queue = {
+      ...queue,
+      tasks: queue.tasks.map((t) =>
+        t.chainPreviousRefId ? { ...t, chainPreviousRefId: undefined } : t,
+      ),
+    };
   }
   await persist();
   return { queue, settings };

--- a/src/background/runner.ts
+++ b/src/background/runner.ts
@@ -1,18 +1,19 @@
 import { MSG } from '../shared/constants';
 import type { ExecuteTaskRequest, TaskResultResponse } from '../shared/protocol';
 import { sleep } from '../shared/sleep';
-import { errorMsg } from '../shared/logger';
+import { errorMsg, logger } from '../shared/logger';
 import {
   getAppState,
   getNextWaitingTask,
   markTaskError,
   markTaskRunning,
   markTaskSuccess,
+  setChainRef,
   setRunning,
 } from './queue-engine';
 import { tryInjectContentScripts } from './content-injection';
 import { sendMessageToTab } from '../shared/messaging';
-import { TIMEOUTS } from '../shared/config';
+import { TIMEOUTS, STEALTH } from '../shared/config';
 
 /** Check whether a tab URL points to a Flow project. */
 function isFlowProjectUrl(url: string): boolean {
@@ -107,12 +108,28 @@ async function runLoop(): Promise<void> {
       await tryInjectContentScripts(tab.id);
       const res = await sendMessageToTab<ExecuteTaskRequest, TaskResultResponse>(
         tab.id,
-        { type: MSG.EXECUTE_TASK, task: next },
+        {
+          type: MSG.EXECUTE_TASK,
+          task: next,
+          stealthMode: settings.stealthMode,
+          chainMode: settings.chainMode,
+        },
         TIMEOUTS.TASK_EXECUTION
       );
 
       if (res.ok) {
         await markTaskSuccess(next.id);
+
+        // Chain propagation: pass captured ref to the next waiting task.
+        if (settings.chainMode && res.chainCapturedRefId) {
+          const nextTask = await getNextWaitingTask();
+          if (nextTask) {
+            await setChainRef(nextTask.id, res.chainCapturedRefId);
+            logger.info(`Chain: propagated ${res.chainCapturedRefId} → task ${nextTask.id.slice(-6)}`);
+          }
+        } else if (settings.chainMode && !res.chainCapturedRefId) {
+          logger.warn('Chain: failed to capture result, next task will run without chain reference');
+        }
       } else {
         await markTaskError(next.id, res.error ?? '执行失败（未知错误）');
       }
@@ -121,8 +138,12 @@ async function runLoop(): Promise<void> {
       await markTaskError(next.id, msg);
     }
 
-    // Inter-task delay (also gives UI time to settle).
-    await sleep(Math.max(0, settings.interTaskDelayMs));
+    // Inter-task delay with optional stealth multiplier.
+    const baseDelay = Math.max(0, settings.interTaskDelayMs);
+    const delay = settings.stealthMode
+      ? baseDelay * (STEALTH.MULTIPLIER_MIN + Math.random() * (STEALTH.MULTIPLIER_MAX - STEALTH.MULTIPLIER_MIN))
+      : baseDelay;
+    await sleep(delay);
   }
 }
 

--- a/src/content/actions/execute-task.ts
+++ b/src/content/actions/execute-task.ts
@@ -24,7 +24,7 @@ import { getProjectName } from "../page-state";
 import { randomSleep, stealthRandomSleep } from "../utils/dom";
 import { selectTab } from "./navigate";
 import { findPromptInput } from "../finders";
-import { saveImageBlob } from "../../shared/image-store";
+import { saveImageBlob, deleteImageBlob } from "../../shared/image-store";
 
 // In-memory blob cache keyed by refId.  Avoids repeated IndexedDB + base64
 // round-trips when the same image (same refId) is needed across tasks.
@@ -283,6 +283,10 @@ export async function executeTask(
         const chainBlob = await fetchAssetBlob(task.chainPreviousRefId);
         log("注入链式引用图");
         await injectImageToFlow(chainBlob, "chain-ref.png", {});
+        // Clean up chain blob from IndexedDB to avoid bloat.
+        if (task.chainPreviousRefId.startsWith("chain-")) {
+          void deleteImageBlob(task.chainPreviousRefId).catch(() => {});
+        }
         await stealthRandomSleep(TIMING.BETWEEN_ASSETS_MIN, TIMING.BETWEEN_ASSETS_MAX, stealth);
       } catch (e: unknown) {
         logger.warn("Chain ref injection failed:", e);
@@ -363,6 +367,10 @@ export async function executeTask(
       const chainBlob = await fetchAssetBlob(task.chainPreviousRefId);
       log("注入链式引用图");
       await injectImageToFlow(chainBlob, "chain-ref.png", {});
+      // Clean up chain blob from IndexedDB to avoid bloat.
+      if (task.chainPreviousRefId.startsWith("chain-")) {
+        void deleteImageBlob(task.chainPreviousRefId).catch(() => {});
+      }
       await stealthRandomSleep(TIMING.LONG_MIN, TIMING.LONG_MAX, stealth);
     } catch (e: unknown) {
       logger.warn("Chain ref injection failed:", e);

--- a/src/content/actions/execute-task.ts
+++ b/src/content/actions/execute-task.ts
@@ -1,5 +1,5 @@
 import { MSG } from "../../shared/constants";
-import { TIMING, TIMEOUTS, LIMITS } from "../../shared/config";
+import { TIMING, TIMEOUTS, LIMITS, STEALTH } from "../../shared/config";
 import { taskLog, logger, errorMsg } from "../../shared/logger";
 import type {
   RefMediaLookupRequest,
@@ -21,9 +21,10 @@ import { clearAttachedReferences, injectImageToFlow } from "./inject-image";
 import { setPromptText } from "./prompt";
 import { setAspectRatio, setMode, setModel, setOutputCount } from "./settings";
 import { getProjectName } from "../page-state";
-import { randomSleep } from "../utils/dom";
+import { randomSleep, stealthRandomSleep } from "../utils/dom";
 import { selectTab } from "./navigate";
 import { findPromptInput } from "../finders";
+import { saveImageBlob } from "../../shared/image-store";
 
 // In-memory blob cache keyed by refId.  Avoids repeated IndexedDB + base64
 // round-trips when the same image (same refId) is needed across tasks.
@@ -201,9 +202,43 @@ export async function resetExecutionSession(options?: {
   }
 }
 
+/**
+ * Capture the latest generation result image for chain propagation.
+ * Saves it to IndexedDB under a chain-specific key.
+ */
+async function captureChainResult(
+  _taskId: string,
+  log: (msg: string) => void,
+): Promise<string | undefined> {
+  const srcs = collectResultImageSrcs();
+  if (srcs.size === 0) return undefined;
+
+  // Pick the last (newest) result image URL.
+  const lastSrc = Array.from(srcs).pop()!;
+  try {
+    const response = await fetch(lastSrc);
+    const blob = await response.blob();
+    const chainRefId = `chain-${Date.now()}`;
+    await saveImageBlob(chainRefId, blob);
+    log(`Chain: captured result as ${chainRefId}`);
+    return chainRefId;
+  } catch (e: unknown) {
+    logger.warn("Chain capture failed:", e);
+    return undefined;
+  }
+}
+
+export interface ExecuteTaskOptions {
+  stealthMode?: boolean;
+  chainMode?: boolean;
+}
+
 export async function executeTask(
   task: TaskItem,
-): Promise<{ downloadedCount: number }> {
+  options: ExecuteTaskOptions = {},
+): Promise<{ downloadedCount: number; chainCapturedRefId?: string }> {
+  const stealth = options.stealthMode ?? false;
+  const chainMode = options.chainMode ?? false;
   const mediaType = mediaTypeForTask(task);
   const log = (msg: string) => taskLog(task.id, msg);
 
@@ -211,22 +246,28 @@ export async function executeTask(
 
   // Keep prompt area clean between tasks.
   await clearAttachedReferences();
-  await randomSleep(TIMING.MEDIUM_MIN, TIMING.MEDIUM_MAX);
+  await stealthRandomSleep(TIMING.MEDIUM_MIN, TIMING.MEDIUM_MAX, stealth);
 
   await selectTab(mediaType === "image" ? "image" : "video");
-  await randomSleep(TIMING.MEDIUM_MIN, TIMING.MEDIUM_MAX);
+  await stealthRandomSleep(TIMING.MEDIUM_MIN, TIMING.MEDIUM_MAX, stealth);
 
   await setMode(task.mode);
-  await randomSleep(TIMING.SHORT_MIN, TIMING.MEDIUM_MIN);
+  await stealthRandomSleep(TIMING.SHORT_MIN, TIMING.MEDIUM_MIN, stealth);
 
   await setAspectRatio(task.aspectRatio);
   await setOutputCount(task.outputCount);
   await setModel(task.model);
-  await randomSleep(TIMING.SHORT_MIN, TIMING.SHORT_MAX);
+  await stealthRandomSleep(TIMING.SHORT_MIN, TIMING.SHORT_MAX, stealth);
 
   log(`参数已就绪：${task.model} · ${task.aspectRatio} · x${task.outputCount}`);
+
+  // Stealth: extra pause between settings and prompt fill.
+  if (stealth) {
+    await randomSleep(STEALTH.PAUSE_MIN_MS, STEALTH.PAUSE_MAX_MS);
+  }
+
   await setPromptText(task.prompt);
-  await randomSleep(TIMING.MEDIUM_MIN, TIMING.MEDIUM_MAX);
+  await stealthRandomSleep(TIMING.MEDIUM_MIN, TIMING.MEDIUM_MAX, stealth);
   log("提示词已填写");
 
   // Attach reference images.  For images that were already uploaded in this
@@ -235,6 +276,18 @@ export async function executeTask(
   if (task.assets && task.assets.length > 0) {
     const projectId = getCurrentProjectId();
     log(`参考图处理中：${task.assets.length} 张`);
+
+    // Inject chain reference first (if present).
+    if (task.chainPreviousRefId) {
+      try {
+        const chainBlob = await fetchAssetBlob(task.chainPreviousRefId);
+        log("注入链式引用图");
+        await injectImageToFlow(chainBlob, "chain-ref.png", {});
+        await stealthRandomSleep(TIMING.BETWEEN_ASSETS_MIN, TIMING.BETWEEN_ASSETS_MAX, stealth);
+      } catch (e: unknown) {
+        logger.warn("Chain ref injection failed:", e);
+      }
+    }
 
     let attachedCount = 0;
     let reusedCount = 0;
@@ -296,14 +349,24 @@ export async function executeTask(
       // Allow Flow's UI to fully settle between sequential injections.
       // Without this, a rapid second paste can displace the first attachment.
       if (i < task.assets.length - 1) {
-        await randomSleep(TIMING.BETWEEN_ASSETS_MIN, TIMING.BETWEEN_ASSETS_MAX);
+        await stealthRandomSleep(TIMING.BETWEEN_ASSETS_MIN, TIMING.BETWEEN_ASSETS_MAX, stealth);
       }
     }
 
     log(
       `参考图已就绪：${attachedCount}/${task.assets.length}（复用 ${reusedCount}，上传 ${uploadedCount}）`,
     );
-    await randomSleep(TIMING.LONG_MIN, TIMING.LONG_MAX);
+    await stealthRandomSleep(TIMING.LONG_MIN, TIMING.LONG_MAX, stealth);
+  } else if (task.chainPreviousRefId) {
+    // No regular assets, but chain ref exists — inject it alone.
+    try {
+      const chainBlob = await fetchAssetBlob(task.chainPreviousRefId);
+      log("注入链式引用图");
+      await injectImageToFlow(chainBlob, "chain-ref.png", {});
+      await stealthRandomSleep(TIMING.LONG_MIN, TIMING.LONG_MAX, stealth);
+    } catch (e: unknown) {
+      logger.warn("Chain ref injection failed:", e);
+    }
   }
 
   const projectName = getProjectName() ?? "Flow";
@@ -315,6 +378,11 @@ export async function executeTask(
   // Preserve the baseline from the first generation round so retries can
   // detect images that loaded late (after the first round's Signal C).
   let originalBaseline: Set<string> | null = null;
+
+  // Stealth: extra pause between prompt fill and generate click.
+  if (stealth) {
+    await randomSleep(STEALTH.PAUSE_MIN_MS, STEALTH.PAUSE_MAX_MS);
+  }
 
   while (remaining > 0 && attempt < LIMITS.MAX_GENERATION_ATTEMPTS) {
     attempt++;
@@ -383,11 +451,11 @@ export async function executeTask(
             document.execCommand("insertText", false, " ");
           }
         }
-        await randomSleep(TIMING.UI_SETTLE_MIN, TIMING.UI_SETTLE_MAX);
+        await stealthRandomSleep(TIMING.UI_SETTLE_MIN, TIMING.UI_SETTLE_MAX, stealth);
       } catch (e) {
         logger.warn("重试前唤醒输入框失败:", e);
       }
-      await randomSleep(TIMING.SHORT_MIN, TIMING.SHORT_MAX);
+      await stealthRandomSleep(TIMING.SHORT_MIN, TIMING.SHORT_MAX, stealth);
     }
 
     let round: { newCount: number; baselineUrls: Set<string> };
@@ -401,7 +469,7 @@ export async function executeTask(
       logger.warn(`生成异常(第${attempt}次): ${msg}`);
       if (attempt < LIMITS.MAX_GENERATION_ATTEMPTS) {
         log(`生成异常，准备重试（还差 ${remaining}）`);
-        await randomSleep(TIMING.RETRY_PAUSE_MIN, TIMING.RETRY_PAUSE_MAX);
+        await stealthRandomSleep(TIMING.RETRY_PAUSE_MIN, TIMING.RETRY_PAUSE_MAX, stealth);
         continue;
       }
       throw new Error(`生成失败: ${msg}`);
@@ -415,7 +483,7 @@ export async function executeTask(
     if (produced <= 0) {
       if (attempt < LIMITS.MAX_GENERATION_ATTEMPTS) {
         log(`本轮未产出结果，准备重试（还差 ${remaining}）`);
-        await randomSleep(TIMING.RETRY_PAUSE_MIN, TIMING.RETRY_PAUSE_MAX);
+        await stealthRandomSleep(TIMING.RETRY_PAUSE_MIN, TIMING.RETRY_PAUSE_MAX, stealth);
         continue;
       }
       throw new Error("生成失败（无新产出）");
@@ -449,7 +517,7 @@ export async function executeTask(
 
     if (remaining > 0 && attempt < LIMITS.MAX_GENERATION_ATTEMPTS) {
       log(`结果不足，自动补生成（剩余 ${remaining}）`);
-      await randomSleep(TIMING.RETRY_PAUSE_MIN, TIMING.RETRY_PAUSE_MAX);
+      await stealthRandomSleep(TIMING.RETRY_PAUSE_MIN, TIMING.RETRY_PAUSE_MAX, stealth);
     }
   }
 
@@ -460,6 +528,18 @@ export async function executeTask(
   }
 
   log(`下载完成：${downloadedTotal} 个文件`);
+
+  // Stealth: extra pause between generation complete and download.
+  if (stealth) {
+    await randomSleep(STEALTH.PAUSE_MIN_MS, STEALTH.PAUSE_MAX_MS);
+  }
+
+  // Chain capture: save the latest result for the next task's reference.
+  let chainCapturedRefId: string | undefined;
+  if (chainMode) {
+    chainCapturedRefId = await captureChainResult(task.id, log);
+  }
+
   log("任务完成");
-  return { downloadedCount: downloadedTotal };
+  return { downloadedCount: downloadedTotal, chainCapturedRefId };
 }

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -65,7 +65,10 @@ chrome.runtime.onMessage.addListener(
     if (message.type === MSG.EXECUTE_TASK) {
       const req = message as ExecuteTaskRequest;
       logger.info(`收到任务执行指令:`, req.task);
-      executeTask(req.task)
+      executeTask(req.task, {
+        stealthMode: req.stealthMode,
+        chainMode: req.chainMode,
+      })
         .then((result) => {
           logger.info(`任务执行成功:`, result);
           sendResponse({
@@ -73,6 +76,7 @@ chrome.runtime.onMessage.addListener(
             taskId: req.task.id,
             ok: true,
             downloadedCount: result.downloadedCount,
+            chainCapturedRefId: result.chainCapturedRefId,
           } satisfies TaskResultResponse);
         })
         .catch((err) => {

--- a/src/content/utils/dom.ts
+++ b/src/content/utils/dom.ts
@@ -1,5 +1,6 @@
 import { getElementName, matchesName, type NameMatcher } from './aria';
 import { logger } from '../../shared/logger';
+import { STEALTH } from '../../shared/config';
 
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -8,6 +9,21 @@ export function sleep(ms: number): Promise<void> {
 export function randomSleep(minMs: number, maxMs: number): Promise<void> {
   const ms = Math.round(minMs + Math.random() * (maxMs - minMs));
   return sleep(ms);
+}
+
+export function calcStealthDelay(minMs: number, maxMs: number, stealth: boolean): [number, number] {
+  if (!stealth) return [minMs, maxMs];
+  const stealthMin = minMs * STEALTH.MULTIPLIER_MIN;
+  const stealthMax = Math.min(
+    maxMs * STEALTH.MULTIPLIER_MAX,
+    maxMs * STEALTH.MAX_SLOWDOWN_FACTOR,
+  );
+  return [stealthMin, stealthMax];
+}
+
+export function stealthRandomSleep(minMs: number, maxMs: number, stealth: boolean): Promise<void> {
+  const [adjMin, adjMax] = calcStealthDelay(minMs, maxMs, stealth);
+  return randomSleep(adjMin, adjMax);
 }
 
 export function isVisible(el: Element): el is HTMLElement {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -98,6 +98,23 @@ export const LIMITS = {
 } as const;
 
 // ============================================
+// Stealth Mode
+// ============================================
+
+export const STEALTH = {
+  /** Minimum delay multiplier when stealth is enabled */
+  MULTIPLIER_MIN: 1.5,
+  /** Maximum delay multiplier when stealth is enabled */
+  MULTIPLIER_MAX: 3.0,
+  /** Minimum inter-step pause in stealth mode (ms) */
+  PAUSE_MIN_MS: 500,
+  /** Maximum inter-step pause in stealth mode (ms) */
+  PAUSE_MAX_MS: 2000,
+  /** Hard cap: stealth delay never exceeds original_max × this factor */
+  MAX_SLOWDOWN_FACTOR: 4,
+} as const;
+
+// ============================================
 // Download & Storage
 // ============================================
 

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -72,6 +72,8 @@ export type SettingsUpdateRequest = {
 export type ExecuteTaskRequest = {
   type: typeof MSG.EXECUTE_TASK;
   task: TaskItem;
+  stealthMode: boolean;
+  chainMode: boolean;
 };
 
 export type TaskLogMessage = {
@@ -86,6 +88,7 @@ export type TaskResultResponse = {
   ok: boolean;
   error?: string;
   downloadedCount?: number;
+  chainCapturedRefId?: string;
 };
 
 export type ResetExecutionSessionRequest = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -85,6 +85,7 @@ export interface TaskItem {
   createdAt: number;
   startedAt?: number;
   completedAt?: number;
+  chainPreviousRefId?: string;
 }
 
 export interface QueueState {
@@ -101,6 +102,8 @@ export interface UserSettings {
   defaultOutputCount: number;
   interTaskDelayMs: number;
   defaultDownloadResolution: DownloadResolution;
+  stealthMode: boolean;
+  chainMode: boolean;
 }
 
 export const DEFAULT_SETTINGS: UserSettings = {
@@ -110,6 +113,8 @@ export const DEFAULT_SETTINGS: UserSettings = {
   defaultOutputCount: 1,
   interTaskDelayMs: 5000,
   defaultDownloadResolution: "2K/1080p",
+  stealthMode: false,
+  chainMode: false,
 };
 
 export const DEFAULT_QUEUE_STATE: QueueState = {

--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -52,6 +52,8 @@
   let s_defaultOutputCount = $state(1);
   let s_defaultDownloadResolution: UserSettings['defaultDownloadResolution'] = $state('2K/1080p');
   let s_interTaskDelayMs = $state(5000);
+  let s_stealthMode = $state(false);
+  let s_chainMode = $state(false);
 
   function sendMessage<TReq, TRes>(message: TReq): Promise<TRes> {
     return new Promise((resolve, reject) => {
@@ -356,6 +358,8 @@
     s_defaultOutputCount = next.defaultOutputCount;
     s_defaultDownloadResolution = next.defaultDownloadResolution;
     s_interTaskDelayMs = next.interTaskDelayMs;
+    s_stealthMode = next.stealthMode;
+    s_chainMode = next.chainMode;
   }
 
   async function patchSettings(patch: Partial<UserSettings>): Promise<void> {
@@ -560,6 +564,8 @@
       bind:s_defaultOutputCount
       bind:s_defaultDownloadResolution
       bind:s_interTaskDelayMs
+      bind:s_stealthMode
+      bind:s_chainMode
       {patchSettings}
     />
 

--- a/src/sidepanel/components/SettingsPanel.svelte
+++ b/src/sidepanel/components/SettingsPanel.svelte
@@ -9,10 +9,12 @@
     s_defaultOutputCount: number;
     s_defaultDownloadResolution: UserSettings['defaultDownloadResolution'];
     s_interTaskDelayMs: number;
+    s_stealthMode: boolean;
+    s_chainMode: boolean;
     patchSettings: (patch: Partial<UserSettings>) => void;
   }
-  
-  let { 
+
+  let {
     settings,
     s_defaultModel = $bindable(),
     s_defaultGenerationType = $bindable(),
@@ -20,6 +22,8 @@
     s_defaultOutputCount = $bindable(),
     s_defaultDownloadResolution = $bindable(),
     s_interTaskDelayMs = $bindable(),
+    s_stealthMode = $bindable(),
+    s_chainMode = $bindable(),
     patchSettings
   }: Props = $props();
 </script>
@@ -111,6 +115,24 @@
           onchange={(e) => patchSettings({ interTaskDelayMs: Number((e.target as HTMLInputElement).value) })}
         />
       </label>
+
+      <label class="toggle-row">
+        <div class="lab">隐身模式</div>
+        <input
+          type="checkbox"
+          bind:checked={s_stealthMode}
+          onchange={() => patchSettings({ stealthMode: s_stealthMode })}
+        />
+      </label>
+
+      <label class="toggle-row">
+        <div class="lab">链式模式</div>
+        <input
+          type="checkbox"
+          bind:checked={s_chainMode}
+          onchange={() => patchSettings({ chainMode: s_chainMode })}
+        />
+      </label>
     </div>
   </details>
 {/if}
@@ -132,6 +154,17 @@
     display: flex;
     flex-direction: column;
     gap: 6px;
+  }
+  .toggle-row {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .toggle-row input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: rgba(126, 231, 135, 0.8);
+    cursor: pointer;
   }
   .lab {
     opacity: 0.7;


### PR DESCRIPTION
## Summary

- **Stealth Mode**: Randomized delay multipliers (1.5-3x) on all `randomSleep` calls across the content script execution pipeline, with extra inter-step pauses and stealth-aware inter-task delay in the runner. Configurable via settings toggle.
- **Chain Mode**: After each task completes, captures the latest generated result image and injects it as a reference for the next queued task. Chain ref propagation through `setChainRef` in queue-engine, blob cleanup after injection to avoid IndexedDB bloat.
- **UI**: Two new checkbox toggles in SettingsPanel (隐身模式 / 链式模式) with full `$bindable()` state sync.
- **Protocol**: `ExecuteTaskRequest` extended with `stealthMode`/`chainMode` flags, `TaskResultResponse` extended with `chainCapturedRefId`.

## Files Changed

| Area | Files |
|------|-------|
| Types & Config | `src/shared/types.ts`, `src/shared/config.ts`, `src/shared/protocol.ts` |
| Background | `src/background/runner.ts`, `src/background/queue-engine.ts` |
| Content Scripts | `src/content/actions/execute-task.ts`, `src/content/index.ts`, `src/content/utils/dom.ts` |
| UI | `src/sidepanel/components/SettingsPanel.svelte`, `src/sidepanel/App.svelte` |
| Tests | `src/__tests__/stealth-mode.test.ts` (new), `src/__tests__/chain-mode.test.ts` (new) |

## Test Plan

- [x] 69 unit tests pass (11 new: 7 stealth constants/delay, 4 chain propagation)
- [x] TypeScript `--noEmit` zero errors
- [x] `npm run build` succeeds
- [ ] Manual: enable stealth, queue 2 tasks → observe 1.5-3x slower delays
- [ ] Manual: enable chain, queue 3 prompts → task 2 gets task 1's result as reference
- [ ] Manual: chain + stealth combined → both behaviors active
- [ ] Manual: chain + task failure → next task runs without reference (no crash)
- [ ] Manual: toggle off → original timing, no chain injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)