### PR TITLE
feat: add AI prompt engine with OpenAI/Gemini providers (P3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ dist-ssr
 *.sw?
 
 console.txt
-har.txt
+har.txt.worktrees

--- a/src/__tests__/ai-provider.test.ts
+++ b/src/__tests__/ai-provider.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------- global fetch mock setup ----------
+const fetchMock = vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>();
+vi.stubGlobal("fetch", fetchMock);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+    redirected: false,
+    statusText: "",
+    type: "basic",
+    url: "",
+    clone: () => jsonResponse(body, status),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+// ---------- imports under test ----------
+import { createAiProvider } from "../background/ai-providers";
+import { OpenAiProvider, parseNumberedList } from "../background/ai-providers/openai-provider";
+import { GeminiProvider } from "../background/ai-providers/gemini-provider";
+import type { AiSettings } from "../shared/ai-provider";
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+// ========== Factory ==========
+describe("createAiProvider", () => {
+  it("returns OpenAiProvider for 'openai'", () => {
+    const s: AiSettings = { provider: "openai", apiKey: "key", model: "gpt-4o-mini" };
+    const p = createAiProvider(s);
+    expect(p).toBeInstanceOf(OpenAiProvider);
+  });
+
+  it("returns GeminiProvider for 'gemini'", () => {
+    const s: AiSettings = { provider: "gemini", apiKey: "key", model: "gemini-2.0-flash" };
+    const p = createAiProvider(s);
+    expect(p).toBeInstanceOf(GeminiProvider);
+  });
+
+  it("throws for 'proxy' (not implemented)", () => {
+    const s: AiSettings = { provider: "proxy", apiKey: "key", model: "" };
+    expect(() => createAiProvider(s)).toThrow(/not yet implemented/i);
+  });
+
+  it("throws for unknown provider", () => {
+    const s = { provider: "foo" as any, apiKey: "key", model: "" };
+    expect(() => createAiProvider(s)).toThrow(/unknown/i);
+  });
+});
+
+// ========== OpenAI Provider ==========
+describe("OpenAiProvider", () => {
+  const provider = new OpenAiProvider("test-key", "gpt-4o-mini");
+
+  it("enhance sends correct request and returns content", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        choices: [{ message: { content: "enhanced prompt" } }],
+      }),
+    );
+
+    const result = await provider.enhance("a cat");
+    expect(result).toBe("enhanced prompt");
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.openai.com/v1/chat/completions");
+    expect((init?.headers as Record<string, string>)["Authorization"]).toBe("Bearer test-key");
+
+    const body = JSON.parse(init?.body as string);
+    expect(body.model).toBe("gpt-4o-mini");
+    expect(body.messages[0].role).toBe("system");
+    expect(body.messages[1].content).toBe("a cat");
+  });
+
+  it("rewrite includes error in system prompt", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        choices: [{ message: { content: "safe prompt" } }],
+      }),
+    );
+
+    const result = await provider.rewrite("bad prompt", "policy violation");
+    expect(result).toBe("safe prompt");
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.messages[0].content).toContain("policy violation");
+  });
+
+  it("variants parses numbered list correctly", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        choices: [{ message: { content: "1. variant one\n2. variant two\n3. variant three" } }],
+      }),
+    );
+
+    const result = await provider.variants("a cat", 3);
+    expect(result).toEqual(["variant one", "variant two", "variant three"]);
+  });
+
+  it("throws on 401 (invalid API key)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "invalid" }, 401));
+    await expect(provider.enhance("test")).rejects.toThrow("Invalid API key (401)");
+  });
+
+  it("throws on 429 (rate limit)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "limit" }, 429));
+    await expect(provider.enhance("test")).rejects.toThrow("Rate limit exceeded (429)");
+  });
+
+  it("throws on empty response", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ choices: [] }));
+    await expect(provider.enhance("test")).rejects.toThrow("Empty response");
+  });
+
+  it("throws on network error", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    await expect(provider.enhance("test")).rejects.toThrow("Failed to fetch");
+  });
+});
+
+// ========== Gemini Provider ==========
+describe("GeminiProvider", () => {
+  const provider = new GeminiProvider("gem-key", "gemini-2.0-flash");
+
+  it("enhance sends correct request and returns content", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        candidates: [{ content: { parts: [{ text: "gemini enhanced" }] } }],
+      }),
+    );
+
+    const result = await provider.enhance("a dog");
+    expect(result).toBe("gemini enhanced");
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("generativelanguage.googleapis.com");
+    expect(url).toContain("key=gem-key");
+    expect(url).toContain("gemini-2.0-flash");
+  });
+
+  it("rewrite includes error in system instruction", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        candidates: [{ content: { parts: [{ text: "safe output" }] } }],
+      }),
+    );
+
+    const result = await provider.rewrite("bad", "content policy");
+    expect(result).toBe("safe output");
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body.systemInstruction.parts[0].text).toContain("content policy");
+  });
+
+  it("variants parses numbered list", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        candidates: [{ content: { parts: [{ text: "1. alpha\n2. beta" }] } }],
+      }),
+    );
+
+    const result = await provider.variants("prompt", 2);
+    expect(result).toEqual(["alpha", "beta"]);
+  });
+
+  it("throws on 401/403 (invalid key)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 403));
+    await expect(provider.enhance("test")).rejects.toThrow("Invalid API key");
+  });
+
+  it("throws on 429 (rate limit)", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 429));
+    await expect(provider.enhance("test")).rejects.toThrow("Rate limit exceeded");
+  });
+
+  it("throws on empty response", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ candidates: [] }));
+    await expect(provider.enhance("test")).rejects.toThrow("Empty response");
+  });
+});
+
+// ========== parseNumberedList ==========
+describe("parseNumberedList", () => {
+  it("parses standard numbered list", () => {
+    expect(parseNumberedList("1. First\n2. Second\n3. Third", 3)).toEqual([
+      "First",
+      "Second",
+      "Third",
+    ]);
+  });
+
+  it("truncates to expected count", () => {
+    expect(parseNumberedList("1. A\n2. B\n3. C\n4. D", 2)).toEqual(["A", "B"]);
+  });
+
+  it("handles fewer items than expected", () => {
+    expect(parseNumberedList("1. Only one", 3)).toEqual(["Only one"]);
+  });
+
+  it("skips blank lines", () => {
+    expect(parseNumberedList("1. A\n\n2. B", 2)).toEqual(["A", "B"]);
+  });
+
+  it("handles text without numbers", () => {
+    expect(parseNumberedList("just plain text\nanother line", 2)).toEqual([
+      "just plain text",
+      "another line",
+    ]);
+  });
+});

--- a/src/background/ai-providers/gemini-provider.ts
+++ b/src/background/ai-providers/gemini-provider.ts
@@ -1,0 +1,70 @@
+import type { AiProvider } from "../../shared/ai-provider";
+import { parseNumberedList } from "./openai-provider";
+
+const SYSTEM_ENHANCE =
+  "You are a prompt engineer for AI image/video generation. Enhance this rough description into a detailed, vivid prompt. Return only the enhanced prompt, nothing else.";
+
+const SYSTEM_REWRITE_PREFIX =
+  "The following prompt was rejected for policy violation. Rewrite it to avoid the violation while keeping the creative intent.";
+
+const SYSTEM_VARIANTS_PREFIX =
+  "Generate creative variations of this prompt for AI image/video generation. Return each variation on a new line, numbered 1. 2. 3. etc.";
+
+export class GeminiProvider implements AiProvider {
+  private apiKey: string;
+  private model: string;
+
+  constructor(apiKey: string, model = "gemini-2.0-flash") {
+    this.apiKey = apiKey;
+    this.model = model;
+  }
+
+  async enhance(prompt: string): Promise<string> {
+    return this.generate(SYSTEM_ENHANCE, prompt);
+  }
+
+  async rewrite(prompt: string, error: string): Promise<string> {
+    const system = `${SYSTEM_REWRITE_PREFIX} Error: ${error}. Return only the rewritten prompt.`;
+    return this.generate(system, prompt);
+  }
+
+  async variants(prompt: string, count: number): Promise<string[]> {
+    const system = SYSTEM_VARIANTS_PREFIX.replace(
+      "Generate creative",
+      `Generate ${count} creative`,
+    );
+    const raw = await this.generate(system, prompt);
+    return parseNumberedList(raw, count);
+  }
+
+  private async generate(system: string, user: string): Promise<string> {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent?key=${this.apiKey}`;
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: system }] },
+        contents: [{ parts: [{ text: user }] }],
+        generationConfig: { temperature: 0.8 },
+      }),
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      throw new Error("Invalid API key (401)");
+    }
+    if (res.status === 429) {
+      throw new Error("Rate limit exceeded (429)");
+    }
+    if (!res.ok) {
+      throw new Error(`Gemini API error (${res.status})`);
+    }
+
+    const data = (await res.json()) as {
+      candidates?: { content?: { parts?: { text?: string }[] } }[];
+    };
+    const content = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+    if (!content) throw new Error("Empty response from Gemini");
+    return content;
+  }
+}

--- a/src/background/ai-providers/index.ts
+++ b/src/background/ai-providers/index.ts
@@ -1,0 +1,19 @@
+import type { AiProvider, AiSettings } from "../../shared/ai-provider";
+import { OpenAiProvider } from "./openai-provider";
+import { GeminiProvider } from "./gemini-provider";
+
+export function createAiProvider(settings: AiSettings): AiProvider {
+  switch (settings.provider) {
+    case "openai":
+      return new OpenAiProvider(settings.apiKey, settings.model || "gpt-4o-mini");
+    case "gemini":
+      return new GeminiProvider(
+        settings.apiKey,
+        settings.model || "gemini-2.0-flash",
+      );
+    case "proxy":
+      throw new Error("Proxy provider is not yet implemented (P6 scope)");
+    default:
+      throw new Error(`Unknown AI provider: ${settings.provider}`);
+  }
+}

--- a/src/background/ai-providers/openai-provider.ts
+++ b/src/background/ai-providers/openai-provider.ts
@@ -1,0 +1,83 @@
+import type { AiProvider } from "../../shared/ai-provider";
+
+const SYSTEM_ENHANCE =
+  "You are a prompt engineer for AI image/video generation. Enhance this rough description into a detailed, vivid prompt. Return only the enhanced prompt, nothing else.";
+
+const SYSTEM_REWRITE_PREFIX =
+  "The following prompt was rejected for policy violation. Rewrite it to avoid the violation while keeping the creative intent.";
+
+const SYSTEM_VARIANTS_PREFIX =
+  "Generate creative variations of this prompt for AI image/video generation. Return each variation on a new line, numbered 1. 2. 3. etc.";
+
+export class OpenAiProvider implements AiProvider {
+  private apiKey: string;
+  private model: string;
+
+  constructor(apiKey: string, model = "gpt-4o-mini") {
+    this.apiKey = apiKey;
+    this.model = model;
+  }
+
+  async enhance(prompt: string): Promise<string> {
+    return this.chat(SYSTEM_ENHANCE, prompt);
+  }
+
+  async rewrite(prompt: string, error: string): Promise<string> {
+    const system = `${SYSTEM_REWRITE_PREFIX} Error: ${error}. Return only the rewritten prompt.`;
+    return this.chat(system, prompt);
+  }
+
+  async variants(prompt: string, count: number): Promise<string[]> {
+    const system = SYSTEM_VARIANTS_PREFIX.replace(
+      "Generate creative",
+      `Generate ${count} creative`,
+    );
+    const raw = await this.chat(system, prompt);
+    return parseNumberedList(raw, count);
+  }
+
+  private async chat(system: string, user: string): Promise<string> {
+    const res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        temperature: 0.8,
+      }),
+    });
+
+    if (res.status === 401) {
+      throw new Error("Invalid API key (401)");
+    }
+    if (res.status === 429) {
+      throw new Error("Rate limit exceeded (429)");
+    }
+    if (!res.ok) {
+      throw new Error(`OpenAI API error (${res.status})`);
+    }
+
+    const data = (await res.json()) as {
+      choices?: { message?: { content?: string } }[];
+    };
+    const content = data.choices?.[0]?.message?.content?.trim();
+    if (!content) throw new Error("Empty response from OpenAI");
+    return content;
+  }
+}
+
+/** Parse a numbered list like "1. foo\n2. bar" into an array of strings. */
+export function parseNumberedList(raw: string, expectedCount: number): string[] {
+  const lines = raw
+    .split("\n")
+    .map((l) => l.replace(/^\d+\.\s*/, "").trim())
+    .filter(Boolean);
+  // Return at most expectedCount items, or all if fewer
+  return lines.slice(0, expectedCount);
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -2,6 +2,12 @@ import { MSG } from "../shared/constants";
 import type {
   AnyRequest,
   AnyResponse,
+  AiEnhanceRequest,
+  AiEnhanceResponse,
+  AiRewriteRequest,
+  AiRewriteResponse,
+  AiVariantsRequest,
+  AiVariantsResponse,
   DownloadByUrlRequest,
   ExpectDownloadRequest,
   ExpectDownloadResponse,
@@ -53,6 +59,7 @@ import { tryInjectContentScripts } from "./content-injection";
 import { sendMessageToTab } from "../shared/messaging";
 import { TIMEOUTS } from "../shared/config";
 import { logger } from "../shared/logger";
+import { createAiProvider } from "./ai-providers";
 
 initDownloadManager();
 
@@ -475,6 +482,58 @@ async function handleRefMediaUpsert(
   return { type: MSG.REF_MEDIA_UPSERT, ok: true };
 }
 
+async function getAiSettingsFromStorage(): Promise<
+  import("../shared/ai-provider").AiSettings | undefined
+> {
+  const { settings } = await getAppState();
+  return settings.aiSettings;
+}
+
+async function handleAiEnhance(
+  req: AiEnhanceRequest,
+): Promise<AiEnhanceResponse> {
+  const aiSettings = await getAiSettingsFromStorage();
+  if (!aiSettings?.apiKey) return { ok: false, error: "未配置 AI 设置" };
+  try {
+    const provider = createAiProvider(aiSettings);
+    const enhanced = await provider.enhance(req.prompt);
+    return { ok: true, enhanced };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg };
+  }
+}
+
+async function handleAiRewrite(
+  req: AiRewriteRequest,
+): Promise<AiRewriteResponse> {
+  const aiSettings = await getAiSettingsFromStorage();
+  if (!aiSettings?.apiKey) return { ok: false, error: "未配置 AI 设置" };
+  try {
+    const provider = createAiProvider(aiSettings);
+    const rewritten = await provider.rewrite(req.prompt, req.errorMessage);
+    return { ok: true, rewritten };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg };
+  }
+}
+
+async function handleAiVariants(
+  req: AiVariantsRequest,
+): Promise<AiVariantsResponse> {
+  const aiSettings = await getAiSettingsFromStorage();
+  if (!aiSettings?.apiKey) return { ok: false, error: "未配置 AI 设置" };
+  try {
+    const provider = createAiProvider(aiSettings);
+    const variants = await provider.variants(req.prompt, req.count);
+    return { ok: true, variants };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: msg };
+  }
+}
+
 async function makeErrorResponse(
   message: AnyRequest,
 ): Promise<AnyResponse | undefined> {
@@ -484,6 +543,12 @@ async function makeErrorResponse(
     return { type: MSG.REF_MEDIA_LOOKUP, found: false };
   if (message.type === MSG.REF_MEDIA_UPSERT)
     return { type: MSG.REF_MEDIA_UPSERT, ok: false };
+  if (
+    message.type === MSG.AI_ENHANCE ||
+    message.type === MSG.AI_REWRITE ||
+    message.type === MSG.AI_VARIANTS
+  )
+    return { ok: false, error: "内部错误" };
   if (message.type === MSG.PING) {
     return {
       type: MSG.PONG,
@@ -556,6 +621,12 @@ chrome.runtime.onMessage.addListener(
           return handleDownloadByUrl(message as DownloadByUrlRequest);
         if (message.type === MSG.GET_IMAGE_BLOB)
           return handleGetImageBlob(message as GetImageBlobRequest);
+        if (message.type === MSG.AI_ENHANCE)
+          return handleAiEnhance(message as AiEnhanceRequest);
+        if (message.type === MSG.AI_REWRITE)
+          return handleAiRewrite(message as AiRewriteRequest);
+        if (message.type === MSG.AI_VARIANTS)
+          return handleAiVariants(message as AiVariantsRequest);
         return undefined;
       } catch {
         return await makeErrorResponse(message);

--- a/src/background/queue-engine.ts
+++ b/src/background/queue-engine.ts
@@ -320,3 +320,26 @@ export async function appendTaskLog(
   };
   await persist();
 }
+
+/** Reset a failed task with a new prompt for retry (used by AI auto-rewrite). */
+export async function resetTaskForRetry(
+  taskId: string,
+  newPrompt: string,
+): Promise<void> {
+  await ensureInitialized();
+  queue = {
+    ...queue,
+    tasks: queue.tasks.map((t) => {
+      if (t.id !== taskId) return t;
+      return {
+        ...t,
+        prompt: newPrompt,
+        status: "waiting" as const,
+        errorMessage: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+      };
+    }),
+  };
+  await persist();
+}

--- a/src/background/runner.ts
+++ b/src/background/runner.ts
@@ -1,18 +1,20 @@
 import { MSG } from '../shared/constants';
 import type { ExecuteTaskRequest, TaskResultResponse } from '../shared/protocol';
 import { sleep } from '../shared/sleep';
-import { errorMsg } from '../shared/logger';
+import { errorMsg, logger } from '../shared/logger';
 import {
   getAppState,
   getNextWaitingTask,
   markTaskError,
   markTaskRunning,
   markTaskSuccess,
+  resetTaskForRetry,
   setRunning,
 } from './queue-engine';
 import { tryInjectContentScripts } from './content-injection';
 import { sendMessageToTab } from '../shared/messaging';
 import { TIMEOUTS } from '../shared/config';
+import { createAiProvider } from './ai-providers';
 
 /** Check whether a tab URL points to a Flow project. */
 function isFlowProjectUrl(url: string): boolean {
@@ -61,6 +63,33 @@ function getTabById(tabId: number): Promise<chrome.tabs.Tab | undefined> {
 }
 
 let loopActive = false;
+
+/** Track tasks that have already been auto-rewritten (one attempt only). */
+const rewrittenTasks = new Set<string>();
+
+function isPolicyViolation(errorMessage: string): boolean {
+  return /内容策略|policy/i.test(errorMessage);
+}
+
+async function tryAutoRewrite(taskId: string, originalPrompt: string, errorMessage: string): Promise<void> {
+  if (!isPolicyViolation(errorMessage)) return;
+  if (rewrittenTasks.has(taskId)) return; // Only one rewrite attempt per task
+
+  const { settings } = await getAppState();
+  const aiSettings = settings.aiSettings;
+  if (!aiSettings?.apiKey) return;
+
+  try {
+    const provider = createAiProvider(aiSettings);
+    const rewritten = await provider.rewrite(originalPrompt, errorMessage);
+    logger.info(`AI 自动改写: "${originalPrompt.slice(0, 30)}..." → "${rewritten.slice(0, 30)}..."`);
+    rewrittenTasks.add(taskId);
+    await resetTaskForRetry(taskId, rewritten);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logger.warn(`AI 自动改写失败: ${msg}`);
+  }
+}
 
 export function kickRunner(): void {
   if (loopActive) return;
@@ -114,11 +143,14 @@ async function runLoop(): Promise<void> {
       if (res.ok) {
         await markTaskSuccess(next.id);
       } else {
-        await markTaskError(next.id, res.error ?? '执行失败（未知错误）');
+        const errText = res.error ?? '执行失败（未知错误）';
+        await markTaskError(next.id, errText);
+        await tryAutoRewrite(next.id, next.prompt, errText);
       }
     } catch (e: unknown) {
       const msg = errorMsg(e);
       await markTaskError(next.id, msg);
+      await tryAutoRewrite(next.id, next.prompt, msg);
     }
 
     // Inter-task delay (also gives UI time to settle).

--- a/src/shared/ai-provider.ts
+++ b/src/shared/ai-provider.ts
@@ -1,0 +1,13 @@
+export interface AiProvider {
+  enhance(prompt: string): Promise<string>;
+  rewrite(prompt: string, error: string): Promise<string>;
+  variants(prompt: string, count: number): Promise<string[]>;
+}
+
+export type AiProviderType = "openai" | "gemini" | "proxy";
+
+export interface AiSettings {
+  provider: AiProviderType;
+  apiKey: string;
+  model: string;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -27,6 +27,10 @@ export const MSG = {
   EXPECT_DOWNLOAD: "EXPECT_DOWNLOAD",
   DOWNLOAD_BY_URL: "DOWNLOAD_BY_URL",
   GET_IMAGE_BLOB: "GET_IMAGE_BLOB",
+
+  AI_ENHANCE: "AI_ENHANCE",
+  AI_REWRITE: "AI_REWRITE",
+  AI_VARIANTS: "AI_VARIANTS",
 } as const;
 
 export type MsgType = (typeof MSG)[keyof typeof MSG];

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -154,6 +154,41 @@ export type GetImageBlobResponse = {
   mimeType?: string;
 };
 
+export type AiEnhanceRequest = {
+  type: typeof MSG.AI_ENHANCE;
+  prompt: string;
+};
+
+export type AiEnhanceResponse = {
+  ok: boolean;
+  enhanced?: string;
+  error?: string;
+};
+
+export type AiRewriteRequest = {
+  type: typeof MSG.AI_REWRITE;
+  prompt: string;
+  errorMessage: string;
+};
+
+export type AiRewriteResponse = {
+  ok: boolean;
+  rewritten?: string;
+  error?: string;
+};
+
+export type AiVariantsRequest = {
+  type: typeof MSG.AI_VARIANTS;
+  prompt: string;
+  count: number;
+};
+
+export type AiVariantsResponse = {
+  ok: boolean;
+  variants?: string[];
+  error?: string;
+};
+
 export type QueueStateResponse = {
   type: typeof MSG.QUEUE_STATE;
   queue: QueueState;
@@ -181,7 +216,10 @@ export type AnyRequest =
   | RefMediaUpsertRequest
   | ExpectDownloadRequest
   | DownloadByUrlRequest
-  | GetImageBlobRequest;
+  | GetImageBlobRequest
+  | AiEnhanceRequest
+  | AiRewriteRequest
+  | AiVariantsRequest;
 
 export type AnyResponse =
   | PongResponse
@@ -193,4 +231,7 @@ export type AnyResponse =
   | RefMediaUpsertResponse
   | ExpectDownloadResponse
   | DownloadByUrlResponse
-  | GetImageBlobResponse;
+  | GetImageBlobResponse
+  | AiEnhanceResponse
+  | AiRewriteResponse
+  | AiVariantsResponse;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -101,6 +101,7 @@ export interface UserSettings {
   defaultOutputCount: number;
   interTaskDelayMs: number;
   defaultDownloadResolution: DownloadResolution;
+  aiSettings?: import("./ai-provider").AiSettings;
 }
 
 export const DEFAULT_SETTINGS: UserSettings = {

--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -22,8 +22,13 @@
     QueueStartRequest,
     QueueStateResponse,
     SettingsUpdateRequest,
+    AiEnhanceRequest,
+    AiEnhanceResponse,
+    AiVariantsRequest,
+    AiVariantsResponse,
   } from '../shared/protocol';
   import { modeForModel } from '../shared/types';
+  import type { AiProviderType } from '../shared/ai-provider';
   import type { GenerationMode, GenerationType, QueueState, TaskAsset, TaskItem, TaskStatus, UserSettings } from '../shared/types';
 
   type Status = 'checking' | 'connected' | 'disconnected';
@@ -52,6 +57,11 @@
   let s_defaultOutputCount = $state(1);
   let s_defaultDownloadResolution: UserSettings['defaultDownloadResolution'] = $state('2K/1080p');
   let s_interTaskDelayMs = $state(5000);
+
+  let s_aiProvider: AiProviderType = $state('openai');
+  let s_aiApiKey = $state('');
+  let s_aiModel = $state('gpt-4o-mini');
+  let aiLoading = $state(false);
 
   function sendMessage<TReq, TRes>(message: TReq): Promise<TRes> {
     return new Promise((resolve, reject) => {
@@ -356,6 +366,11 @@
     s_defaultOutputCount = next.defaultOutputCount;
     s_defaultDownloadResolution = next.defaultDownloadResolution;
     s_interTaskDelayMs = next.interTaskDelayMs;
+    if (next.aiSettings) {
+      s_aiProvider = next.aiSettings.provider;
+      s_aiApiKey = next.aiSettings.apiKey;
+      s_aiModel = next.aiSettings.model;
+    }
   }
 
   async function patchSettings(patch: Partial<UserSettings>): Promise<void> {
@@ -546,6 +561,50 @@
   function dismissImportSummary() {
     importSummary = null;
   }
+
+  async function handleAiEnhance(): Promise<void> {
+    if (!promptText.trim() || aiLoading) return;
+    aiLoading = true;
+    queueError = '';
+    try {
+      const res = await sendMessage<AiEnhanceRequest, AiEnhanceResponse>({
+        type: MSG.AI_ENHANCE,
+        prompt: promptText.trim(),
+      });
+      if (res.ok && res.enhanced) {
+        promptText = res.enhanced;
+      } else {
+        queueError = res.error ?? 'AI 增强失败';
+      }
+    } catch {
+      queueError = 'AI 增强请求失败';
+    } finally {
+      aiLoading = false;
+    }
+  }
+
+  async function handleAiVariants(): Promise<void> {
+    if (!promptText.trim() || aiLoading) return;
+    aiLoading = true;
+    queueError = '';
+    try {
+      const res = await sendMessage<AiVariantsRequest, AiVariantsResponse>({
+        type: MSG.AI_VARIANTS,
+        prompt: promptText.trim(),
+        count: 3,
+      });
+      if (res.ok && res.variants?.length) {
+        const variantsText = res.variants.join('\n');
+        promptText = promptText.trim() + '\n' + variantsText;
+      } else {
+        queueError = res.error ?? '生成变体失败';
+      }
+    } catch {
+      queueError = '生成变体请求失败';
+    } finally {
+      aiLoading = false;
+    }
+  }
 </script>
 
 <main>
@@ -560,6 +619,9 @@
       bind:s_defaultOutputCount
       bind:s_defaultDownloadResolution
       bind:s_interTaskDelayMs
+      bind:s_aiProvider
+      bind:s_aiApiKey
+      bind:s_aiModel
       {patchSettings}
     />
 
@@ -580,6 +642,10 @@
       canClearHistory={!!queue && !queue.isRunning && (counts(queue).success + counts(queue).error + counts(queue).skipped) > 0}
       hasQueue={!!queue}
       onUpdatePrompt={(text) => promptText = text}
+      onAiEnhance={handleAiEnhance}
+      onAiVariants={handleAiVariants}
+      {aiLoading}
+      hasAiSettings={!!s_aiApiKey}
     />
 
     {#if queueError}

--- a/src/sidepanel/components/SettingsPanel.svelte
+++ b/src/sidepanel/components/SettingsPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { UserSettings } from '../../shared/types';
-  
+  import type { AiProviderType } from '../../shared/ai-provider';
+
   interface Props {
     settings: UserSettings | null;
     s_defaultModel: UserSettings['defaultModel'];
@@ -9,10 +10,13 @@
     s_defaultOutputCount: number;
     s_defaultDownloadResolution: UserSettings['defaultDownloadResolution'];
     s_interTaskDelayMs: number;
+    s_aiProvider: AiProviderType;
+    s_aiApiKey: string;
+    s_aiModel: string;
     patchSettings: (patch: Partial<UserSettings>) => void;
   }
-  
-  let { 
+
+  let {
     settings,
     s_defaultModel = $bindable(),
     s_defaultGenerationType = $bindable(),
@@ -20,8 +24,18 @@
     s_defaultOutputCount = $bindable(),
     s_defaultDownloadResolution = $bindable(),
     s_interTaskDelayMs = $bindable(),
+    s_aiProvider = $bindable(),
+    s_aiApiKey = $bindable(),
+    s_aiModel = $bindable(),
     patchSettings
   }: Props = $props();
+
+  function patchAi(patch: Partial<{ provider: AiProviderType; apiKey: string; model: string }>): void {
+    const current = settings?.aiSettings ?? { provider: s_aiProvider, apiKey: s_aiApiKey, model: s_aiModel };
+    patchSettings({
+      aiSettings: { ...current, ...patch },
+    });
+  }
 </script>
 
 {#if settings}
@@ -113,6 +127,51 @@
       </label>
     </div>
   </details>
+
+  <details class="settings">
+    <summary>AI 设置</summary>
+    <div class="grid">
+      <label>
+        <div class="lab">AI 服务商</div>
+        <select
+          class="sel"
+          bind:value={s_aiProvider}
+          onchange={(e) => patchAi({ provider: (e.target as HTMLSelectElement).value as AiProviderType })}
+        >
+          <option value="openai">OpenAI</option>
+          <option value="gemini">Gemini</option>
+        </select>
+      </label>
+
+      <label>
+        <div class="lab">模型</div>
+        <select
+          class="sel"
+          bind:value={s_aiModel}
+          onchange={(e) => patchAi({ model: (e.target as HTMLSelectElement).value })}
+        >
+          {#if s_aiProvider === 'openai'}
+            <option value="gpt-4o-mini">gpt-4o-mini</option>
+            <option value="gpt-4o">gpt-4o</option>
+          {:else}
+            <option value="gemini-2.0-flash">gemini-2.0-flash</option>
+            <option value="gemini-2.5-pro-preview-05-06">gemini-2.5-pro</option>
+          {/if}
+        </select>
+      </label>
+
+      <label class="full-width">
+        <div class="lab">API Key</div>
+        <input
+          class="inp"
+          type="password"
+          placeholder="输入 API Key"
+          bind:value={s_aiApiKey}
+          onchange={(e) => patchAi({ apiKey: (e.target as HTMLInputElement).value })}
+        />
+      </label>
+    </div>
+  </details>
 {/if}
 
 <style>
@@ -155,5 +214,8 @@
   .sel:focus,
   .inp:focus {
     border-color: rgba(126, 231, 135, 0.45);
+  }
+  .full-width {
+    grid-column: 1 / -1;
   }
 </style>

--- a/src/sidepanel/components/TaskInput.svelte
+++ b/src/sidepanel/components/TaskInput.svelte
@@ -27,6 +27,10 @@
     canClearHistory: boolean;
     hasQueue: boolean;
     onUpdatePrompt: (text: string) => void;
+    onAiEnhance: () => void;
+    onAiVariants: () => void;
+    aiLoading: boolean;
+    hasAiSettings: boolean;
   }
   
   let {
@@ -45,7 +49,11 @@
     hasError,
     canClearHistory,
     hasQueue,
-    onUpdatePrompt
+    onUpdatePrompt,
+    onAiEnhance,
+    onAiVariants,
+    aiLoading,
+    hasAiSettings
   }: Props = $props();
   
   let fileInput: HTMLInputElement | undefined = $state(undefined);
@@ -68,6 +76,17 @@
     导入
   </button>
 </div>
+
+{#if hasAiSettings}
+  <div class="ai-row">
+    <button class="btn btn-ai" onclick={onAiEnhance} disabled={aiLoading || !promptText.trim()}>
+      {aiLoading ? '处理中...' : 'AI 增强'}
+    </button>
+    <button class="btn btn-ai" onclick={onAiVariants} disabled={aiLoading || !promptText.trim()}>
+      {aiLoading ? '处理中...' : '生成变体'}
+    </button>
+  </div>
+{/if}
 
 {#if s_defaultGenerationType === 'image-to-image' || s_defaultGenerationType === 'image-to-video'}
   <div class="import-row">
@@ -296,5 +315,20 @@
     padding-left: 8px;
     padding-right: 8px;
     font-size: 12px;
+  }
+  .ai-row {
+    display: flex;
+    gap: 6px;
+    margin-top: 6px;
+  }
+  .btn-ai {
+    flex: 1;
+    font-size: 11px;
+    padding: 4px 8px;
+    background: rgba(168, 130, 255, 0.10);
+    border-color: rgba(168, 130, 255, 0.30);
+  }
+  .btn-ai:hover {
+    background: rgba(168, 130, 255, 0.18);
   }
 </style>


### PR DESCRIPTION
## Summary

- **AI Provider adapter**: `AiProvider` interface with `enhance`, `rewrite`, `variants` methods and factory function
- **OpenAI Provider**: Chat Completions API integration (default: gpt-4o-mini), handles 401/429/network errors
- **Gemini Provider**: GenerateContent API integration (default: gemini-2.0-flash)
- **UI integration**: "AI 增强" and "生成变体" buttons in TaskInput, AI settings section in SettingsPanel (provider, model, API key)
- **Auto-rewrite**: On policy violation failure, attempts AI rewrite and resets task for retry (one attempt per task)

## Files Changed

| Area | Files |
|------|-------|
| Shared | `ai-provider.ts` (new), `types.ts`, `constants.ts`, `protocol.ts` |
| Background | `ai-providers/` (new: openai, gemini, index), `runner.ts`, `queue-engine.ts`, `index.ts` |
| UI | `TaskInput.svelte`, `SettingsPanel.svelte` |
| Tests | `ai-provider.test.ts` (21 tests) |

## Test Plan

- [x] 80 unit tests pass (21 new AI provider tests)
- [x] `tsc --noEmit` zero errors
- [ ] Manual: configure OpenAI key, test enhance/variants
- [ ] Manual: configure Gemini key, test enhance/variants
- [ ] Manual: trigger policy violation → verify auto-rewrite attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)