### PR TITLE
feat: add Telegram/Discord notification integration (P4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ dist-ssr
 *.sw?
 
 console.txt
-har.txt
+har.txt.worktrees

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "Automate Google Flow (DOM-first) with a side panel queue.",
   "permissions": ["storage", "downloads", "tabs", "activeTab", "sidePanel", "scripting"],
-  "host_permissions": ["https://labs.google/*"],
+  "host_permissions": ["https://labs.google/*", "https://api.telegram.org/*", "https://discord.com/api/webhooks/*"],
   "action": {
     "default_title": "FlowAuto"
   },

--- a/src/__tests__/notification.test.ts
+++ b/src/__tests__/notification.test.ts
@@ -1,0 +1,187 @@
+import './chrome-mock';
+import {
+  sendTelegram,
+  sendDiscord,
+  sendNotification,
+  DEFAULT_NOTIFICATION_SETTINGS,
+  type NotificationSettings,
+} from '../background/notifier';
+import { formatQueueCompleteMessage, formatTaskErrorMessage } from '../background/notifier';
+
+// Global fetch mock
+const fetchMock = vi.fn();
+globalThis.fetch = fetchMock;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe('sendTelegram', () => {
+  it('calls the correct Telegram API URL with proper payload', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+
+    await sendTelegram('BOT_TOKEN_123', '999', 'Hello');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.telegram.org/botBOT_TOKEN_123/sendMessage');
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(opts.body);
+    expect(body.chat_id).toBe('999');
+    expect(body.text).toBe('Hello');
+    expect(body.parse_mode).toBe('HTML');
+  });
+
+  it('throws on non-ok response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('Bad Request'),
+    });
+
+    await expect(sendTelegram('tok', 'cid', 'msg')).rejects.toThrow(
+      'Telegram API error 400: Bad Request',
+    );
+  });
+});
+
+describe('sendDiscord', () => {
+  it('calls the webhook URL with proper payload', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+
+    const webhookUrl = 'https://discord.com/api/webhooks/123/abc';
+    await sendDiscord(webhookUrl, 'Test message');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe(webhookUrl);
+    expect(opts.method).toBe('POST');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+    const body = JSON.parse(opts.body);
+    expect(body.content).toBe('Test message');
+  });
+
+  it('throws on non-ok response', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: () => Promise.resolve('Rate limited'),
+    });
+
+    await expect(
+      sendDiscord('https://discord.com/api/webhooks/x/y', 'msg'),
+    ).rejects.toThrow('Discord webhook error 429: Rate limited');
+  });
+});
+
+describe('sendNotification', () => {
+  it('does nothing when provider is none', async () => {
+    await sendNotification(DEFAULT_NOTIFICATION_SETTINGS, 'test');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('routes to Telegram when provider is telegram', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+
+    const settings: NotificationSettings = {
+      provider: 'telegram',
+      telegramBotToken: 'tok123',
+      telegramChatId: 'chat456',
+      notifyOnComplete: true,
+      notifyOnError: true,
+    };
+    await sendNotification(settings, 'hello');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('api.telegram.org');
+  });
+
+  it('routes to Discord when provider is discord', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+
+    const settings: NotificationSettings = {
+      provider: 'discord',
+      discordWebhookUrl: 'https://discord.com/api/webhooks/1/abc',
+      notifyOnComplete: true,
+      notifyOnError: true,
+    };
+    await sendNotification(settings, 'hello');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain('discord.com');
+  });
+
+  it('skips Telegram when token is missing', async () => {
+    const settings: NotificationSettings = {
+      provider: 'telegram',
+      telegramChatId: 'chat456',
+      notifyOnComplete: true,
+      notifyOnError: true,
+    };
+    await sendNotification(settings, 'hello');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips Telegram when chatId is missing', async () => {
+    const settings: NotificationSettings = {
+      provider: 'telegram',
+      telegramBotToken: 'tok123',
+      notifyOnComplete: true,
+      notifyOnError: true,
+    };
+    await sendNotification(settings, 'hello');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips Discord when webhookUrl is missing', async () => {
+    const settings: NotificationSettings = {
+      provider: 'discord',
+      notifyOnComplete: true,
+      notifyOnError: true,
+    };
+    await sendNotification(settings, 'hello');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('formatQueueCompleteMessage', () => {
+  it('formats queue completion message', () => {
+    const msg = formatQueueCompleteMessage('MyProject', 5, 2, 120_000);
+    expect(msg).toContain('MyProject');
+    expect(msg).toContain('5');
+    expect(msg).toContain('2');
+    expect(msg).toContain('2m 0s');
+  });
+
+  it('formats elapsed time in seconds when under a minute', () => {
+    const msg = formatQueueCompleteMessage('P', 1, 0, 45_000);
+    expect(msg).toContain('45s');
+  });
+
+  it('uses fallback project name when empty', () => {
+    const msg = formatQueueCompleteMessage('', 1, 0, 1000);
+    expect(msg).toContain('未命名项目');
+  });
+});
+
+describe('formatTaskErrorMessage', () => {
+  it('formats error notification with truncation', () => {
+    const longPrompt = 'A'.repeat(80);
+    const longError = 'E'.repeat(150);
+    const msg = formatTaskErrorMessage(longPrompt, longError);
+
+    // Prompt truncated to 50 chars
+    expect(msg).toContain('A'.repeat(47) + '...');
+    // Error truncated to 100 chars
+    expect(msg).toContain('E'.repeat(97) + '...');
+  });
+
+  it('does not truncate short strings', () => {
+    const msg = formatTaskErrorMessage('short prompt', 'short error');
+    expect(msg).toContain('short prompt');
+    expect(msg).toContain('short error');
+  });
+});

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -29,6 +29,8 @@ import type {
   RefMediaLookupResponse,
   RefMediaUpsertRequest,
   RefMediaUpsertResponse,
+  TestNotificationRequest,
+  TestNotificationResponse,
 } from "../shared/protocol";
 import { getImageAsBase64 } from "../shared/image-store";
 import {
@@ -53,6 +55,7 @@ import { tryInjectContentScripts } from "./content-injection";
 import { sendMessageToTab } from "../shared/messaging";
 import { TIMEOUTS } from "../shared/config";
 import { logger } from "../shared/logger";
+import { sendNotification } from "./notifier";
 
 initDownloadManager();
 
@@ -475,6 +478,18 @@ async function handleRefMediaUpsert(
   return { type: MSG.REF_MEDIA_UPSERT, ok: true };
 }
 
+async function handleTestNotification(
+  req: TestNotificationRequest,
+): Promise<TestNotificationResponse> {
+  try {
+    await sendNotification(req.settings, '\u{1F514} FlowAuto 测试通知 - 配置成功！');
+    return { type: MSG.TEST_NOTIFICATION, ok: true };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { type: MSG.TEST_NOTIFICATION, ok: false, error: msg };
+  }
+}
+
 async function makeErrorResponse(
   message: AnyRequest,
 ): Promise<AnyResponse | undefined> {
@@ -556,6 +571,8 @@ chrome.runtime.onMessage.addListener(
           return handleDownloadByUrl(message as DownloadByUrlRequest);
         if (message.type === MSG.GET_IMAGE_BLOB)
           return handleGetImageBlob(message as GetImageBlobRequest);
+        if (message.type === MSG.TEST_NOTIFICATION)
+          return handleTestNotification(message as TestNotificationRequest);
         return undefined;
       } catch {
         return await makeErrorResponse(message);

--- a/src/background/notifier.ts
+++ b/src/background/notifier.ts
@@ -1,0 +1,107 @@
+import type { NotificationSettings } from '../shared/types';
+import { logger } from '../shared/logger';
+
+export { DEFAULT_NOTIFICATION_SETTINGS } from '../shared/types';
+export type { NotificationSettings, NotificationProvider } from '../shared/types';
+
+export async function sendTelegram(
+  token: string,
+  chatId: string,
+  message: string,
+): Promise<void> {
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId, text: message, parse_mode: 'HTML' }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Telegram API error ${res.status}: ${text}`);
+  }
+}
+
+export async function sendDiscord(
+  webhookUrl: string,
+  message: string,
+): Promise<void> {
+  const res = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: message }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Discord webhook error ${res.status}: ${text}`);
+  }
+}
+
+export async function sendNotification(
+  settings: NotificationSettings,
+  message: string,
+): Promise<void> {
+  if (settings.provider === 'none') return;
+
+  if (settings.provider === 'telegram') {
+    if (!settings.telegramBotToken || !settings.telegramChatId) return;
+    await sendTelegram(settings.telegramBotToken, settings.telegramChatId, message);
+  }
+
+  if (settings.provider === 'discord') {
+    if (!settings.discordWebhookUrl) return;
+    await sendDiscord(settings.discordWebhookUrl, message);
+  }
+}
+
+/** Best-effort notification: logs warning on failure, never throws. */
+export async function trySendNotification(
+  settings: NotificationSettings,
+  message: string,
+): Promise<void> {
+  try {
+    await sendNotification(settings, message);
+  } catch (e) {
+    logger.warn('通知发送失败', e);
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min === 0) return `${sec}s`;
+  return `${min}m ${sec}s`;
+}
+
+export function formatQueueCompleteMessage(
+  projectName: string,
+  successCount: number,
+  errorCount: number,
+  elapsedMs: number,
+): string {
+  const name = projectName || '未命名项目';
+  return [
+    '\u{1F3AC} FlowAuto 批量任务完成',
+    '',
+    `项目: ${name}`,
+    `\u2705 成功: ${successCount}`,
+    `\u274C 失败: ${errorCount}`,
+    `\u23F1 耗时: ${formatElapsed(elapsedMs)}`,
+  ].join('\n');
+}
+
+export function formatTaskErrorMessage(
+  prompt: string,
+  errorMessage: string,
+): string {
+  return [
+    '\u26A0\uFE0F FlowAuto 任务失败',
+    '',
+    `任务: ${truncate(prompt, 50)}`,
+    `错误: ${truncate(errorMessage, 100)}`,
+  ].join('\n');
+}

--- a/src/background/runner.ts
+++ b/src/background/runner.ts
@@ -13,6 +13,11 @@ import {
 import { tryInjectContentScripts } from './content-injection';
 import { sendMessageToTab } from '../shared/messaging';
 import { TIMEOUTS } from '../shared/config';
+import {
+  trySendNotification,
+  formatQueueCompleteMessage,
+  formatTaskErrorMessage,
+} from './notifier';
 
 /** Check whether a tab URL points to a Flow project. */
 function isFlowProjectUrl(url: string): boolean {
@@ -79,15 +84,23 @@ async function runLoop(): Promise<void> {
   // This allows the user to switch to other tabs without breaking execution.
   let lockedTabId: number | undefined;
 
+  const startedAt = Date.now();
+  let successCount = 0;
+  let errorCount = 0;
+  let projectName = '';
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
     const { queue, settings } = await getAppState();
-    if (!queue.isRunning) return;
+    if (!queue.isRunning) break;
+
+    // Capture project name from queue state (may be set by user).
+    if (queue.projectName) projectName = queue.projectName;
 
     const next = await getNextWaitingTask();
     if (!next) {
       await setRunning(false);
-      return;
+      break;
     }
 
     await markTaskRunning(next.id);
@@ -95,13 +108,18 @@ async function runLoop(): Promise<void> {
     // Re-verify the locked tab before each task (it may have been closed or navigated away).
     const tab = await resolveFlowTab(lockedTabId);
     if (!tab?.id) {
-      await markTaskError(next.id, '未找到可用的 Flow 项目页（请切到 Flow 项目页标签后重试）');
+      const tabError = '未找到可用的 Flow 项目页（请切到 Flow 项目页标签后重试）';
+      await markTaskError(next.id, tabError);
+      errorCount++;
       await setRunning(false);
-      return;
+      break;
     }
 
     // Lock onto this tab for all subsequent tasks in this loop.
     lockedTabId = tab.id;
+
+    let taskFailed = false;
+    let taskErrorMsg = '';
 
     try {
       await tryInjectContentScripts(tab.id);
@@ -113,17 +131,38 @@ async function runLoop(): Promise<void> {
 
       if (res.ok) {
         await markTaskSuccess(next.id);
+        successCount++;
       } else {
-        await markTaskError(next.id, res.error ?? '执行失败（未知错误）');
+        taskErrorMsg = res.error ?? '执行失败（未知错误）';
+        await markTaskError(next.id, taskErrorMsg);
+        errorCount++;
+        taskFailed = true;
       }
     } catch (e: unknown) {
-      const msg = errorMsg(e);
-      await markTaskError(next.id, msg);
+      taskErrorMsg = errorMsg(e);
+      await markTaskError(next.id, taskErrorMsg);
+      errorCount++;
+      taskFailed = true;
+    }
+
+    // Immediate error notification
+    if (taskFailed && settings.notificationSettings?.notifyOnError) {
+      const msg = formatTaskErrorMessage(next.prompt, taskErrorMsg);
+      void trySendNotification(settings.notificationSettings, msg);
     }
 
     // Inter-task delay (also gives UI time to settle).
     await sleep(Math.max(0, settings.interTaskDelayMs));
   }
+
+  // Queue completion notification
+  const elapsed = Date.now() - startedAt;
+  const totalProcessed = successCount + errorCount;
+  if (totalProcessed > 0) {
+    const { settings } = await getAppState();
+    if (settings.notificationSettings?.notifyOnComplete) {
+      const msg = formatQueueCompleteMessage(projectName, successCount, errorCount, elapsed);
+      void trySendNotification(settings.notificationSettings, msg);
+    }
+  }
 }
-
-

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -27,6 +27,7 @@ export const MSG = {
   EXPECT_DOWNLOAD: "EXPECT_DOWNLOAD",
   DOWNLOAD_BY_URL: "DOWNLOAD_BY_URL",
   GET_IMAGE_BLOB: "GET_IMAGE_BLOB",
+  TEST_NOTIFICATION: "TEST_NOTIFICATION",
 } as const;
 
 export type MsgType = (typeof MSG)[keyof typeof MSG];

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -1,6 +1,7 @@
 import { MSG } from "./constants";
 import type {
   GenerationMode,
+  NotificationSettings,
   ParsedPromptItem,
   QueueState,
   TaskItem,
@@ -160,6 +161,17 @@ export type QueueStateResponse = {
   settings: UserSettings;
 };
 
+export type TestNotificationRequest = {
+  type: typeof MSG.TEST_NOTIFICATION;
+  settings: NotificationSettings;
+};
+
+export type TestNotificationResponse = {
+  type: typeof MSG.TEST_NOTIFICATION;
+  ok: boolean;
+  error?: string;
+};
+
 export type AnyRequest =
   | PingRequest
   | GetPageStateRequest
@@ -181,7 +193,8 @@ export type AnyRequest =
   | RefMediaUpsertRequest
   | ExpectDownloadRequest
   | DownloadByUrlRequest
-  | GetImageBlobRequest;
+  | GetImageBlobRequest
+  | TestNotificationRequest;
 
 export type AnyResponse =
   | PongResponse
@@ -193,4 +206,5 @@ export type AnyResponse =
   | RefMediaUpsertResponse
   | ExpectDownloadResponse
   | DownloadByUrlResponse
-  | GetImageBlobResponse;
+  | GetImageBlobResponse
+  | TestNotificationResponse;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -94,6 +94,23 @@ export interface QueueState {
   projectName?: string;
 }
 
+export type NotificationProvider = 'telegram' | 'discord' | 'none';
+
+export interface NotificationSettings {
+  provider: NotificationProvider;
+  telegramBotToken?: string;
+  telegramChatId?: string;
+  discordWebhookUrl?: string;
+  notifyOnComplete: boolean;
+  notifyOnError: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  provider: 'none',
+  notifyOnComplete: true,
+  notifyOnError: true,
+};
+
 export interface UserSettings {
   defaultModel: AnyModel;
   defaultGenerationType: GenerationType;
@@ -101,6 +118,7 @@ export interface UserSettings {
   defaultOutputCount: number;
   interTaskDelayMs: number;
   defaultDownloadResolution: DownloadResolution;
+  notificationSettings: NotificationSettings;
 }
 
 export const DEFAULT_SETTINGS: UserSettings = {
@@ -110,6 +128,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   defaultOutputCount: 1,
   interTaskDelayMs: 5000,
   defaultDownloadResolution: "2K/1080p",
+  notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
 };
 
 export const DEFAULT_QUEUE_STATE: QueueState = {

--- a/src/sidepanel/components/SettingsPanel.svelte
+++ b/src/sidepanel/components/SettingsPanel.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import type { UserSettings } from '../../shared/types';
-  
+  import type { NotificationProvider, NotificationSettings } from '../../shared/types';
+  import { DEFAULT_NOTIFICATION_SETTINGS } from '../../shared/types';
+  import { MSG } from '../../shared/constants';
+  import type { TestNotificationRequest, TestNotificationResponse } from '../../shared/protocol';
+
   interface Props {
     settings: UserSettings | null;
     s_defaultModel: UserSettings['defaultModel'];
@@ -11,8 +15,8 @@
     s_interTaskDelayMs: number;
     patchSettings: (patch: Partial<UserSettings>) => void;
   }
-  
-  let { 
+
+  let {
     settings,
     s_defaultModel = $bindable(),
     s_defaultGenerationType = $bindable(),
@@ -22,6 +26,71 @@
     s_interTaskDelayMs = $bindable(),
     patchSettings
   }: Props = $props();
+
+  // Notification settings local state
+  let nProvider: NotificationProvider = $state('none');
+  let nTelegramBotToken = $state('');
+  let nTelegramChatId = $state('');
+  let nDiscordWebhookUrl = $state('');
+  let nNotifyOnComplete = $state(true);
+  let nNotifyOnError = $state(true);
+  let testStatus: '' | 'sending' | 'ok' | 'error' = $state('');
+  let testError = $state('');
+
+  // Sync notification settings from parent settings
+  $effect(() => {
+    if (!settings) return;
+    const ns = settings.notificationSettings ?? DEFAULT_NOTIFICATION_SETTINGS;
+    nProvider = ns.provider;
+    nTelegramBotToken = ns.telegramBotToken ?? '';
+    nTelegramChatId = ns.telegramChatId ?? '';
+    nDiscordWebhookUrl = ns.discordWebhookUrl ?? '';
+    nNotifyOnComplete = ns.notifyOnComplete;
+    nNotifyOnError = ns.notifyOnError;
+  });
+
+  function buildNotificationSettings(): NotificationSettings {
+    return {
+      provider: nProvider,
+      telegramBotToken: nTelegramBotToken || undefined,
+      telegramChatId: nTelegramChatId || undefined,
+      discordWebhookUrl: nDiscordWebhookUrl || undefined,
+      notifyOnComplete: nNotifyOnComplete,
+      notifyOnError: nNotifyOnError,
+    };
+  }
+
+  function saveNotificationSettings(): void {
+    patchSettings({ notificationSettings: buildNotificationSettings() });
+  }
+
+  async function testNotification(): Promise<void> {
+    testStatus = 'sending';
+    testError = '';
+    try {
+      const res = await new Promise<TestNotificationResponse>((resolve, reject) => {
+        chrome.runtime.sendMessage(
+          { type: MSG.TEST_NOTIFICATION, settings: buildNotificationSettings() } satisfies TestNotificationRequest,
+          (response: TestNotificationResponse) => {
+            if (chrome.runtime.lastError) {
+              reject(new Error(chrome.runtime.lastError.message));
+              return;
+            }
+            resolve(response);
+          },
+        );
+      });
+      if (res.ok) {
+        testStatus = 'ok';
+      } else {
+        testStatus = 'error';
+        testError = res.error ?? '未知错误';
+      }
+    } catch (e) {
+      testStatus = 'error';
+      testError = e instanceof Error ? e.message : String(e);
+    }
+  }
 </script>
 
 {#if settings}
@@ -113,6 +182,99 @@
       </label>
     </div>
   </details>
+
+  <details class="settings">
+    <summary>通知设置</summary>
+    <div class="grid">
+      <label>
+        <div class="lab">通知渠道</div>
+        <select
+          class="sel"
+          bind:value={nProvider}
+          onchange={() => saveNotificationSettings()}
+        >
+          <option value="none">无</option>
+          <option value="telegram">Telegram</option>
+          <option value="discord">Discord</option>
+        </select>
+      </label>
+    </div>
+
+    {#if nProvider === 'telegram'}
+      <div class="grid">
+        <label>
+          <div class="lab">Bot Token</div>
+          <input
+            class="inp"
+            type="password"
+            placeholder="123456:ABC-DEF..."
+            bind:value={nTelegramBotToken}
+            onchange={() => saveNotificationSettings()}
+          />
+        </label>
+        <label>
+          <div class="lab">Chat ID</div>
+          <input
+            class="inp"
+            type="text"
+            placeholder="-100123456789"
+            bind:value={nTelegramChatId}
+            onchange={() => saveNotificationSettings()}
+          />
+        </label>
+      </div>
+    {/if}
+
+    {#if nProvider === 'discord'}
+      <div class="grid single">
+        <label>
+          <div class="lab">Webhook URL</div>
+          <input
+            class="inp"
+            type="password"
+            placeholder="https://discord.com/api/webhooks/..."
+            bind:value={nDiscordWebhookUrl}
+            onchange={() => saveNotificationSettings()}
+          />
+        </label>
+      </div>
+    {/if}
+
+    <div class="triggers">
+      <label class="ck">
+        <input
+          type="checkbox"
+          bind:checked={nNotifyOnComplete}
+          onchange={() => saveNotificationSettings()}
+        />
+        队列完成时通知
+      </label>
+      <label class="ck">
+        <input
+          type="checkbox"
+          bind:checked={nNotifyOnError}
+          onchange={() => saveNotificationSettings()}
+        />
+        任务失败时通知
+      </label>
+    </div>
+
+    {#if nProvider !== 'none'}
+      <button
+        class="test-btn"
+        disabled={testStatus === 'sending'}
+        onclick={testNotification}
+      >
+        {testStatus === 'sending' ? '发送中...' : '测试通知'}
+      </button>
+      {#if testStatus === 'ok'}
+        <span class="test-ok">发送成功</span>
+      {/if}
+      {#if testStatus === 'error'}
+        <span class="test-err">{testError}</span>
+      {/if}
+    {/if}
+  </details>
 {/if}
 
 <style>
@@ -122,11 +284,17 @@
     font-size: 12px;
     margin-bottom: 10px;
   }
+  .settings {
+    margin-bottom: 8px;
+  }
   .grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 10px 10px;
     margin-bottom: 10px;
+  }
+  .grid.single {
+    grid-template-columns: 1fr;
   }
   label {
     display: flex;
@@ -155,5 +323,48 @@
   .sel:focus,
   .inp:focus {
     border-color: rgba(126, 231, 135, 0.45);
+  }
+  .triggers {
+    display: flex;
+    gap: 16px;
+    margin-bottom: 10px;
+  }
+  .ck {
+    flex-direction: row;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    opacity: 0.85;
+    cursor: pointer;
+  }
+  .ck input[type="checkbox"] {
+    accent-color: rgba(126, 231, 135, 0.8);
+  }
+  .test-btn {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.06);
+    color: inherit;
+    border-radius: 10px;
+    padding: 6px 14px;
+    font-size: 12px;
+    cursor: pointer;
+    margin-bottom: 4px;
+  }
+  .test-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+  .test-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .test-ok {
+    font-size: 11px;
+    color: rgba(126, 231, 135, 0.9);
+    margin-left: 8px;
+  }
+  .test-err {
+    font-size: 11px;
+    color: rgba(255, 100, 100, 0.9);
+    margin-left: 8px;
   }
 </style>


### PR DESCRIPTION
## Summary

- **Notifier module**: `sendTelegram` (Bot API), `sendDiscord` (webhook), `sendNotification` (router), `trySendNotification` (best-effort wrapper)
- **Runner integration**: Queue completion summary notification (project name, success/error counts, elapsed time) and immediate error notifications
- **Settings UI**: Collapsible notification section with provider select, conditional credential inputs, trigger checkboxes, test notification button
- **Manifest**: Added `api.telegram.org` and `discord.com/api/webhooks` to `host_permissions`

## Files Changed

| Area | Files |
|------|-------|
| Background | `notifier.ts` (new), `runner.ts`, `index.ts` |
| Shared | `types.ts`, `constants.ts`, `protocol.ts` |
| UI | `SettingsPanel.svelte` |
| Config | `manifest.json` |
| Tests | `notification.test.ts` (15 tests) |

## Test Plan

- [x] 73 unit tests pass (15 new notification tests)
- [x] `tsc --noEmit` zero errors
- [ ] Manual: configure Telegram bot, send test notification
- [ ] Manual: configure Discord webhook, send test notification
- [ ] Manual: run queue → verify completion notification sent
- [ ] Manual: trigger task error → verify error notification sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)