### PR TITLE
feat: add AI proxy backend and ProxyProvider (P6)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "flowauto-ai-proxy",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^3.0.0",
+    "@cloudflare/workers-types": "^4.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,232 @@
+interface Env {
+  OPENAI_API_KEY: string;
+  RATE_LIMIT: KVNamespace;
+}
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, X-License-Key",
+};
+
+const MONTHLY_QUOTA = 500;
+const LICENSE_CACHE_TTL = 3600; // 1 hour
+const QUOTA_TTL = 35 * 24 * 3600; // 35 days
+
+const SYSTEM_ENHANCE =
+  "You are a prompt engineer for AI image/video generation. Enhance this rough description into a detailed, vivid prompt. Return only the enhanced prompt, nothing else.";
+
+const SYSTEM_REWRITE_PREFIX =
+  "The following prompt was rejected for policy violation. Rewrite it to avoid the violation while keeping the creative intent.";
+
+const SYSTEM_VARIANTS_PREFIX =
+  "Generate creative variations of this prompt for AI image/video generation. Return each variation on a new line, numbered 1. 2. 3. etc.";
+
+// ---------- helpers ----------
+
+function json(body: unknown, status = 200, extra: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS_HEADERS, ...extra },
+  });
+}
+
+function corsResponse(): Response {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
+
+function monthKey(): string {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+// ---------- license validation ----------
+
+async function validateLicense(env: Env, licenseKey: string): Promise<boolean> {
+  // Check cache first
+  const cacheKey = `license:${licenseKey}`;
+  const cached = await env.RATE_LIMIT.get(cacheKey);
+  if (cached !== null) return cached === "valid";
+
+  try {
+    const res = await fetch("https://api.lemonsqueezy.com/v1/licenses/validate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ license_key: licenseKey }),
+    });
+
+    const data = (await res.json()) as { valid?: boolean };
+    const valid = data.valid === true;
+
+    // Cache result for 1 hour
+    await env.RATE_LIMIT.put(cacheKey, valid ? "valid" : "invalid", {
+      expirationTtl: LICENSE_CACHE_TTL,
+    });
+
+    return valid;
+  } catch {
+    // On network error, deny access
+    return false;
+  }
+}
+
+// ---------- rate limiting ----------
+
+async function getRemainingQuota(env: Env, licenseKey: string): Promise<number> {
+  const key = `quota:${licenseKey}:${monthKey()}`;
+  const val = await env.RATE_LIMIT.get(key);
+  if (val === null) return MONTHLY_QUOTA;
+  return parseInt(val, 10);
+}
+
+async function decrementQuota(env: Env, licenseKey: string, remaining: number): Promise<void> {
+  const key = `quota:${licenseKey}:${monthKey()}`;
+  await env.RATE_LIMIT.put(key, String(remaining - 1), {
+    expirationTtl: QUOTA_TTL,
+  });
+}
+
+// ---------- OpenAI calls ----------
+
+async function chatCompletion(
+  env: Env,
+  system: string,
+  user: string,
+): Promise<string> {
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+      temperature: 0.8,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`OpenAI error: ${res.status}`);
+  }
+
+  const data = (await res.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  const content = data.choices?.[0]?.message?.content?.trim();
+  if (!content) throw new Error("Empty response from OpenAI");
+  return content;
+}
+
+// ---------- handlers ----------
+
+async function handleEnhance(
+  request: Request,
+  env: Env,
+  remaining: number,
+  licenseKey: string,
+): Promise<Response> {
+  const { prompt } = (await request.json()) as { prompt: string };
+  if (!prompt) return json({ error: "Missing prompt" }, 400);
+
+  const result = await chatCompletion(env, SYSTEM_ENHANCE, prompt);
+  await decrementQuota(env, licenseKey, remaining);
+
+  return json({ result }, 200, {
+    "X-AI-Quota-Remaining": String(remaining - 1),
+  });
+}
+
+async function handleRewrite(
+  request: Request,
+  env: Env,
+  remaining: number,
+  licenseKey: string,
+): Promise<Response> {
+  const { prompt, error } = (await request.json()) as {
+    prompt: string;
+    error: string;
+  };
+  if (!prompt) return json({ error: "Missing prompt" }, 400);
+
+  const system = `${SYSTEM_REWRITE_PREFIX} Error: ${error}. Return only the rewritten prompt.`;
+  const result = await chatCompletion(env, system, prompt);
+  await decrementQuota(env, licenseKey, remaining);
+
+  return json({ result }, 200, {
+    "X-AI-Quota-Remaining": String(remaining - 1),
+  });
+}
+
+async function handleVariants(
+  request: Request,
+  env: Env,
+  remaining: number,
+  licenseKey: string,
+): Promise<Response> {
+  const { prompt, count = 3 } = (await request.json()) as {
+    prompt: string;
+    count?: number;
+  };
+  if (!prompt) return json({ error: "Missing prompt" }, 400);
+
+  const system = SYSTEM_VARIANTS_PREFIX.replace(
+    "Generate creative",
+    `Generate ${count} creative`,
+  );
+  const raw = await chatCompletion(env, system, prompt);
+
+  const result = raw
+    .split("\n")
+    .map((l) => l.replace(/^\d+\.\s*/, "").trim())
+    .filter(Boolean)
+    .slice(0, count);
+
+  await decrementQuota(env, licenseKey, remaining);
+
+  return json({ result }, 200, {
+    "X-AI-Quota-Remaining": String(remaining - 1),
+  });
+}
+
+// ---------- entry ----------
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === "OPTIONS") return corsResponse();
+
+    const url = new URL(request.url);
+
+    // License key validation
+    const licenseKey = request.headers.get("X-License-Key");
+    if (!licenseKey) return json({ error: "Missing license key" }, 401);
+
+    const valid = await validateLicense(env, licenseKey);
+    if (!valid) return json({ error: "Invalid license key" }, 403);
+
+    // Rate limiting
+    const remaining = await getRemainingQuota(env, licenseKey);
+    if (remaining <= 0) return json({ error: "Monthly quota exceeded" }, 429);
+
+    // Route
+    try {
+      if (url.pathname === "/api/ai/enhance" && request.method === "POST") {
+        return await handleEnhance(request, env, remaining, licenseKey);
+      }
+      if (url.pathname === "/api/ai/rewrite" && request.method === "POST") {
+        return await handleRewrite(request, env, remaining, licenseKey);
+      }
+      if (url.pathname === "/api/ai/variants" && request.method === "POST") {
+        return await handleVariants(request, env, remaining, licenseKey);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Internal error";
+      return json({ error: message }, 502);
+    }
+
+    return json({ error: "Not found" }, 404);
+  },
+};

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"]
+}

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -1,0 +1,10 @@
+name = "flowauto-ai-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[vars]
+OPENAI_API_KEY = ""  # Set via wrangler secret
+
+[[kv_namespaces]]
+binding = "RATE_LIMIT"
+id = ""  # Will be created with wrangler

--- a/src/__tests__/ai-provider.test.ts
+++ b/src/__tests__/ai-provider.test.ts
@@ -29,6 +29,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 import { createAiProvider } from "../background/ai-providers";
 import { OpenAiProvider, parseNumberedList } from "../background/ai-providers/openai-provider";
 import { GeminiProvider } from "../background/ai-providers/gemini-provider";
+import { ProxyProvider } from "../background/ai-providers/proxy-provider";
 import type { AiSettings } from "../shared/ai-provider";
 
 beforeEach(() => {
@@ -49,9 +50,15 @@ describe("createAiProvider", () => {
     expect(p).toBeInstanceOf(GeminiProvider);
   });
 
-  it("throws for 'proxy' (not implemented)", () => {
-    const s: AiSettings = { provider: "proxy", apiKey: "key", model: "" };
-    expect(() => createAiProvider(s)).toThrow(/not yet implemented/i);
+  it("returns ProxyProvider for 'proxy' with licenseKey", () => {
+    const s: AiSettings = { provider: "proxy", apiKey: "", model: "", licenseKey: "lk_123" };
+    const p = createAiProvider(s);
+    expect(p).toBeInstanceOf(ProxyProvider);
+  });
+
+  it("throws for 'proxy' without licenseKey", () => {
+    const s: AiSettings = { provider: "proxy", apiKey: "", model: "" };
+    expect(() => createAiProvider(s)).toThrow(/license key required/i);
   });
 
   it("throws for unknown provider", () => {

--- a/src/__tests__/proxy-provider.test.ts
+++ b/src/__tests__/proxy-provider.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------- global fetch mock setup ----------
+const fetchMock = vi.fn<
+  (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+>();
+vi.stubGlobal("fetch", fetchMock);
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  const h = new Headers(headers);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: h,
+    redirected: false,
+    statusText: "",
+    type: "basic",
+    url: "",
+    clone: () => jsonResponse(body, status, headers),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    blob: () => Promise.resolve(new Blob()),
+    formData: () => Promise.resolve(new FormData()),
+    bytes: () => Promise.resolve(new Uint8Array()),
+  } as Response;
+}
+
+// ---------- import under test ----------
+import { ProxyProvider } from "../background/ai-providers/proxy-provider";
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("ProxyProvider", () => {
+  const provider = new ProxyProvider("test-license-key");
+
+  // ========== enhance ==========
+  describe("enhance", () => {
+    it("sends correct request and returns result", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ result: "enhanced prompt" }),
+      );
+
+      const result = await provider.enhance("a cat");
+      expect(result).toBe("enhanced prompt");
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://flowauto-ai-proxy.workers.dev/api/ai/enhance",
+      );
+      expect(init?.method).toBe("POST");
+      expect(
+        (init?.headers as Record<string, string>)["X-License-Key"],
+      ).toBe("test-license-key");
+      expect(
+        (init?.headers as Record<string, string>)["Content-Type"],
+      ).toBe("application/json");
+
+      const body = JSON.parse(init?.body as string);
+      expect(body).toEqual({ prompt: "a cat" });
+    });
+  });
+
+  // ========== rewrite ==========
+  describe("rewrite", () => {
+    it("sends prompt and error, returns result", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ result: "safe prompt" }),
+      );
+
+      const result = await provider.rewrite("bad prompt", "policy violation");
+      expect(result).toBe("safe prompt");
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://flowauto-ai-proxy.workers.dev/api/ai/rewrite",
+      );
+      const body = JSON.parse(init?.body as string);
+      expect(body).toEqual({ prompt: "bad prompt", error: "policy violation" });
+    });
+  });
+
+  // ========== variants ==========
+  describe("variants", () => {
+    it("returns array result directly", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ result: ["v1", "v2", "v3"] }),
+      );
+
+      const result = await provider.variants("a cat", 3);
+      expect(result).toEqual(["v1", "v2", "v3"]);
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://flowauto-ai-proxy.workers.dev/api/ai/variants",
+      );
+      const body = JSON.parse(init?.body as string);
+      expect(body).toEqual({ prompt: "a cat", count: 3 });
+    });
+
+    it("wraps non-array result in array", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ result: "single variant" }),
+      );
+
+      const result = await provider.variants("a cat", 1);
+      expect(result).toEqual(["single variant"]);
+    });
+  });
+
+  // ========== error handling ==========
+  describe("error handling", () => {
+    it("throws quota exceeded on 429", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: "Monthly quota exceeded" }, 429),
+      );
+
+      await expect(provider.enhance("test")).rejects.toThrow(
+        "AI quota exceeded",
+      );
+    });
+
+    it("throws auth error on 401", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: "Missing license key" }, 401),
+      );
+
+      await expect(provider.enhance("test")).rejects.toThrow("AI proxy error: 401");
+    });
+
+    it("throws auth error on 403", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: "Invalid license key" }, 403),
+      );
+
+      await expect(provider.enhance("test")).rejects.toThrow("AI proxy error: 403");
+    });
+
+    it("throws on generic server error", async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonResponse({ error: "Internal error" }, 500),
+      );
+
+      await expect(provider.enhance("test")).rejects.toThrow("AI proxy error: 500");
+    });
+
+    it("throws on network error", async () => {
+      fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+      await expect(provider.enhance("test")).rejects.toThrow("Failed to fetch");
+    });
+  });
+});

--- a/src/background/ai-providers/index.ts
+++ b/src/background/ai-providers/index.ts
@@ -1,6 +1,7 @@
 import type { AiProvider, AiSettings } from "../../shared/ai-provider";
 import { OpenAiProvider } from "./openai-provider";
 import { GeminiProvider } from "./gemini-provider";
+import { ProxyProvider } from "./proxy-provider";
 
 export function createAiProvider(settings: AiSettings): AiProvider {
   switch (settings.provider) {
@@ -12,7 +13,10 @@ export function createAiProvider(settings: AiSettings): AiProvider {
         settings.model || "gemini-2.0-flash",
       );
     case "proxy":
-      throw new Error("Proxy provider is not yet implemented (P6 scope)");
+      if (!settings.licenseKey) {
+        throw new Error("License key required for proxy provider");
+      }
+      return new ProxyProvider(settings.licenseKey);
     default:
       throw new Error(`Unknown AI provider: ${settings.provider}`);
   }

--- a/src/background/ai-providers/proxy-provider.ts
+++ b/src/background/ai-providers/proxy-provider.ts
@@ -1,0 +1,49 @@
+import type { AiProvider } from "../../shared/ai-provider";
+
+const PROXY_BASE_URL = "https://flowauto-ai-proxy.workers.dev";
+
+export class ProxyProvider implements AiProvider {
+  private licenseKey: string;
+
+  constructor(licenseKey: string) {
+    this.licenseKey = licenseKey;
+  }
+
+  async enhance(prompt: string): Promise<string> {
+    return this.call("/api/ai/enhance", { prompt });
+  }
+
+  async rewrite(prompt: string, error: string): Promise<string> {
+    return this.call("/api/ai/rewrite", { prompt, error });
+  }
+
+  async variants(prompt: string, count: number): Promise<string[]> {
+    const result = await this.call("/api/ai/variants", { prompt, count });
+    return Array.isArray(result) ? result : [result];
+  }
+
+  private async call(
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<any> {
+    const res = await fetch(`${PROXY_BASE_URL}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-License-Key": this.licenseKey,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (res.status === 429) {
+      throw new Error("AI quota exceeded");
+    }
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`AI proxy error: ${res.status} ${text}`);
+    }
+
+    const data = (await res.json()) as { result: unknown };
+    return data.result;
+  }
+}

--- a/src/shared/ai-provider.ts
+++ b/src/shared/ai-provider.ts
@@ -10,4 +10,5 @@ export interface AiSettings {
   provider: AiProviderType;
   apiKey: string;
   model: string;
+  licenseKey?: string;
 }

--- a/src/sidepanel/components/SettingsPanel.svelte
+++ b/src/sidepanel/components/SettingsPanel.svelte
@@ -242,9 +242,13 @@
         >
           <option value="openai">OpenAI</option>
           <option value="gemini">Gemini</option>
+          {#if isFeatureEnabled('ai_proxy', tier)}
+            <option value="proxy">代理 (Pro+)</option>
+          {/if}
         </select>
       </label>
 
+      {#if s_aiProvider !== 'proxy'}
       <label>
         <div class="lab">模型</div>
         <select
@@ -272,6 +276,9 @@
           onchange={(e) => patchAi({ apiKey: (e.target as HTMLInputElement).value })}
         />
       </label>
+      {:else}
+      <p class="proxy-hint full-width">使用 FlowAuto 代理，无需 API Key</p>
+      {/if}
     </div>
   </details>
   {/if}
@@ -411,4 +418,5 @@
   .test-ok { color: rgba(126, 231, 135, 0.9); font-size: 11px; }
   .test-err { color: rgba(255, 100, 100, 0.9); font-size: 11px; }
   .lock { font-size: 10px; margin-left: 4px; opacity: 0.6; }
+  .proxy-hint { font-size: 11px; opacity: 0.6; margin: 0; }
 </style>


### PR DESCRIPTION
## Summary
- Cloudflare Worker (`api/`): 3 AI endpoints with license validation + 500/month rate limiting
- ProxyProvider: extension-side AiProvider delegating to worker with X-License-Key
- UI: "代理 (Pro+)" option in AI provider dropdown

## Test Plan
- [x] 180 tests pass (10 new)
- [x] `tsc --noEmit` zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)